### PR TITLE
Implement masonry layout for events

### DIFF
--- a/pages/events.js
+++ b/pages/events.js
@@ -17,9 +17,9 @@ export default function Page(){
           <h2 className="text-2xl font-semibold mb-2">Sessions d’initiation</h2>
           <p>Des sessions courtes pour comprendre les bases de la data science et démarrer vos premiers projets.</p>
         </div>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="masonry">
           {[1,2,3,4].map(n => (
-            <div key={n} className="h-32 bg-gray-200 rounded" />
+            <div key={n} className="masonry-item h-32 bg-gray-200 rounded" />
           ))}
         </div>
         <p className="mt-4">Replays complets disponibles sur <a href="#" className="text-tealBrand underline">Instagram</a> et <a href="#" className="text-tealBrand underline">YouTube</a>.</p>

--- a/pages/index.js
+++ b/pages/index.js
@@ -61,7 +61,7 @@ export default function Home() {
       <section id="events" className="py-20 bg-lightGray">
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Nos Événements</h2>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+          <div className="masonry">
             <EventCard img="/event1.jpg" title="Atelier Machine Learning" tag="Atelier" />
             <EventCard img="/event2.jpg" title="Introduction à Python" tag="Session" />
             <EventCard img="/event3.jpg" title="Live IA" tag="Live" />
@@ -132,7 +132,7 @@ function Objective({ icon: Icon, title }){
 
 function EventCard({ img, title, tag }){
   return (
-    <div className="bg-white rounded-lg shadow hover:shadow-xl transition overflow-hidden">
+    <div className="masonry-item bg-white rounded-lg shadow hover:shadow-xl transition overflow-hidden">
       <Image src={img} alt={title} width={400} height={250} className="w-full h-48 object-cover" />
       <div className="p-4">
         <span className="text-xs uppercase tracking-wider text-dsccOrange">{tag}</span>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -15,6 +15,25 @@ body {
   100% { transform: translateX(100%); }
 }
 
-.slide-right {
-  animation: slideRight 20s linear infinite;
+  .slide-right {
+    animation: slideRight 20s linear infinite;
+  }
+
+@layer utilities {
+  .masonry {
+    column-gap: 1rem;
+  }
+  @screen sm {
+    .masonry { column-count: 2; }
+  }
+  @screen md {
+    .masonry { column-count: 3; }
+  }
+  @screen lg {
+    .masonry { column-count: 4; }
+  }
+  .masonry-item {
+    break-inside: avoid;
+    margin-bottom: 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- define new `masonry` and `masonry-item` utilities in global CSS
- use masonry layout in the events page
- update home page event previews and EventCard for masonry

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4a439f688331ae171ea331b15c96