### PR TITLE
Add counters and sponsors slider

### DIFF
--- a/components/Counter.js
+++ b/components/Counter.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+export default function Counter({ to = 0, duration = 1000 }) {
+  const [count, setCount] = useState(0)
+
+  useEffect(() => {
+    let current = 0
+    const stepTime = Math.max(20, duration / to)
+    const timer = setInterval(() => {
+      current += 1
+      if (current >= to) {
+        current = to
+        clearInterval(timer)
+      }
+      setCount(current)
+    }, stepTime)
+
+    return () => clearInterval(timer)
+  }, [to, duration])
+
+  return <span>{count}</span>
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,4 +1,6 @@
 import Layout from '../components/Layout'
+import Counter from '../components/Counter'
+import ImageSlider from '../components/ImageSlider'
 
 export default function Page(){
   return (
@@ -30,12 +32,38 @@ export default function Page(){
             <li><strong>Secrétaire :</strong> D. Salma</li>
           </ul>
         </div>
+        <div>
+          <h2 className="text-2xl font-semibold mb-4">Chiffres clés</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
+            <div>
+              <p className="text-4xl font-bold text-dsccOrange">
+                <Counter to={12} />
+              </p>
+              <p className="uppercase tracking-wide text-sm">Projets</p>
+            </div>
+            <div>
+              <p className="text-4xl font-bold text-dsccOrange">
+                <Counter to={45} />
+              </p>
+              <p className="uppercase tracking-wide text-sm">Membres actifs</p>
+            </div>
+          </div>
+        </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {[1,2].map(n => (
             <div key={n} className="p-4 border rounded-lg hover:bg-tealBrand hover:text-white transition">
               “J’ai appris à collaborer et à innover grâce au club.”
             </div>
           ))}
+        </div>
+        <div>
+          <h2 className="text-2xl font-semibold mb-4">Ils nous font confiance</h2>
+          <ImageSlider images={[
+            '/sponsors/google.svg',
+            '/sponsors/amazon.svg',
+            '/sponsors/microsoft.svg',
+            '/sponsors/facebook.svg',
+          ]} />
         </div>
       </section>
     </Layout>

--- a/public/sponsors/amazon.svg
+++ b/public/sponsors/amazon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80">
+  <rect width="200" height="80" fill="white" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#FF9900">Amazon</text>
+</svg>

--- a/public/sponsors/facebook.svg
+++ b/public/sponsors/facebook.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80">
+  <rect width="200" height="80" fill="white" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#4267B2">Facebook</text>
+</svg>

--- a/public/sponsors/google.svg
+++ b/public/sponsors/google.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80">
+  <rect width="200" height="80" fill="white" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#4285F4">Google</text>
+</svg>

--- a/public/sponsors/microsoft.svg
+++ b/public/sponsors/microsoft.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80">
+  <rect width="200" height="80" fill="white" />
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="32" fill="#F25022">Microsoft</text>
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,6 +19,15 @@ body {
     animation: slideRight 20s linear infinite;
   }
 
+@keyframes slideLeft {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+  .slide-left {
+    animation: slideLeft 20s linear infinite;
+  }
+
 @layer utilities {
   .masonry {
     column-gap: 1rem;


### PR DESCRIPTION
## Summary
- create a `Counter` component with simple count-up animation
- add `slide-left` animation in global styles
- show counters for project and member totals on the About page
- add an auto-scrolling sponsor logo slider
- include placeholder sponsor SVGs

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a4d6b8bc8833180eeee5d0292b3dc