### PR TITLE
Fix counters & section animations

### DIFF
--- a/components/AnimatedSection.js
+++ b/components/AnimatedSection.js
@@ -23,9 +23,10 @@ export default function AnimatedSection({
   }
 
   const variants = {
-    hidden: { opacity: 0, ...computeOffset(direction) },
+    hidden: { opacity: 0, scale: 0.9, ...computeOffset(direction) },
     visible: {
       opacity: 1,
+      scale: 1,
       x: 0,
       y: 0,
       transition: { staggerChildren: stagger, delayChildren: delay }
@@ -37,7 +38,7 @@ export default function AnimatedSection({
       className={className}
       initial="hidden"
       whileInView="visible"
-      viewport={{ once: true, amount: 0.2 }}
+      viewport={{ once: false, amount: 0.2 }}
       transition={{ duration: 0.8, delay }}
       variants={variants}
       {...props}

--- a/components/Counter.js
+++ b/components/Counter.js
@@ -1,9 +1,15 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
+import { useInView } from 'framer-motion'
 
 export default function Counter({ to = 0, duration = 1000 }) {
+  const ref = useRef(null)
+  const isInView = useInView(ref, { once: false })
   const [count, setCount] = useState(0)
 
   useEffect(() => {
+    if (!isInView) return
+
+    setCount(0)
     let current = 0
     const stepTime = Math.max(20, duration / to)
     const timer = setInterval(() => {
@@ -16,7 +22,7 @@ export default function Counter({ to = 0, duration = 1000 }) {
     }, stepTime)
 
     return () => clearInterval(timer)
-  }, [to, duration])
+  }, [isInView, to, duration])
 
-  return <span>{count}+</span>
+  return <span ref={ref}>{count}+</span>
 }


### PR DESCRIPTION
## Summary
- make animated sections replay when scrolled into view
- add subtle zoom effect on section reveal
- restart counters whenever they enter the viewport

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next: not found)*


------
https://chatgpt.com/codex/tasks/task_e_686a6632c76083318f0d889ce1f97678