### PR TITLE
Enhance UI with icons and endless logo list

### DIFF
--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,5 +1,6 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
+import { FaPaperPlane, FaInstagram, FaLinkedin, FaGithub } from 'react-icons/fa'
 
 export default function Page(){
   return (
@@ -10,15 +11,24 @@ export default function Page(){
           <input required placeholder="Nom" className="border p-2 w-full rounded" />
           <input required type="email" placeholder="Email" className="border p-2 w-full rounded" />
           <textarea required placeholder="Message" className="border p-2 w-full rounded h-32" />
-          <button type="submit" className="bg-dsccOrange text-white px-4 py-2 rounded">Envoyer</button>
+          <button type="submit" className="bg-dsccOrange text-white px-4 py-2 rounded inline-flex items-center gap-2">
+            <span>Envoyer</span>
+            <FaPaperPlane />
+          </button>
         </form>
         <div className="w-full h-64">
           <iframe title="map" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d0!2d-6.852!3d33.971!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xda76bad1cd!2sENSA!5e0!3m2!1sfr!2sma!4v000000" width="100%" height="100%" style={{border:0}} allowFullScreen loading="lazy" referrerPolicy="no-referrer-when-downgrade"></iframe>
         </div>
         <div className="flex gap-4">
-          <a href="https://instagram.com/clubdscc" className="text-dsccGreen underline">Instagram</a>
-          <a href="https://linkedin.com" className="text-dsccGreen underline">LinkedIn</a>
-          <a href="https://github.com" className="text-dsccGreen underline">GitHub</a>
+          <a href="https://instagram.com/clubdscc" className="text-dsccGreen underline inline-flex items-center gap-1">
+            <FaInstagram /> Instagram
+          </a>
+          <a href="https://linkedin.com" className="text-dsccGreen underline inline-flex items-center gap-1">
+            <FaLinkedin /> LinkedIn
+          </a>
+          <a href="https://github.com" className="text-dsccGreen underline inline-flex items-center gap-1">
+            <FaGithub /> GitHub
+          </a>
         </div>
       </AnimatedSection>
     </Layout>

--- a/pages/datathonx.js
+++ b/pages/datathonx.js
@@ -1,5 +1,6 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
+import { FaPaperPlane } from 'react-icons/fa'
 
 export default function Page(){
   return (
@@ -55,7 +56,10 @@ export default function Page(){
           <h2 className="text-2xl font-semibold">Inscription prochaine édition</h2>
           <input required placeholder="Nom" className="border p-2 w-full rounded" />
           <input required type="email" placeholder="Email" className="border p-2 w-full rounded" />
-          <button type="submit" className="bg-dsccOrange text-white px-4 py-2 rounded">Envoyer</button>
+          <button type="submit" className="bg-dsccOrange text-white px-4 py-2 rounded inline-flex items-center gap-2">
+            <span>Envoyer</span>
+            <FaPaperPlane />
+          </button>
         </form>
       </AnimatedSection>
     </Layout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import Counter from '../components/Counter';
 import Layout from '../components/Layout';
 import Image from 'next/image';
-import { FaRegCalendarAlt, FaUserPlus, FaRocket, FaLightbulb, FaHandshake, FaGoogle, FaMicrosoft, FaAmazon, FaApple, FaFacebook, FaProjectDiagram, FaUsers } from 'react-icons/fa';
+import { FaRegCalendarAlt, FaUserPlus, FaRocket, FaLightbulb, FaHandshake, FaGoogle, FaMicrosoft, FaAmazon, FaApple, FaFacebook, FaProjectDiagram, FaUsers, FaArrowRight } from 'react-icons/fa';
 import AnimatedSection from '../components/AnimatedSection'
 
 export default function Home() {
@@ -47,11 +47,13 @@ export default function Home() {
             l’innovation et la collaboration autour de la science des données.
           </p>
           <div className="flex gap-4 justify-center flex-wrap">
-            <Link href="/events" className="bg-dsccOrange hover:bg-white hover:text-dsccOrange text-white font-semibold px-6 py-3 rounded-md transition">
-              Nos Événements
+            <Link href="/events" className="bg-dsccOrange hover:bg-white hover:text-dsccOrange text-white font-semibold px-6 py-3 rounded-md transition inline-flex items-center gap-2">
+              <span>Nos Événements</span>
+              <FaRegCalendarAlt />
             </Link>
-            <Link href="/join" className="bg-white text-dsccGreen hover:bg-dsccGreen hover:text-white font-semibold px-6 py-3 rounded-md transition">
-              Rejoindre le Club
+            <Link href="/join" className="bg-white text-dsccGreen hover:bg-dsccGreen hover:text-white font-semibold px-6 py-3 rounded-md transition inline-flex items-center gap-2">
+              <span>Rejoindre le Club</span>
+              <FaUserPlus />
             </Link>
           </div>
         </motion.div>
@@ -70,9 +72,11 @@ export default function Home() {
           <h2 className="text-3xl font-bold text-center mb-8">Ils nous font confiance</h2>
           <div className="overflow-hidden">
             <div className="flex flex-nowrap items-center gap-10 w-max slide-left">
-              {[FaGoogle, FaMicrosoft, FaAmazon, FaApple, FaFacebook, FaGoogle, FaMicrosoft, FaAmazon, FaApple, FaFacebook].map((Icon, i) => (
-                <IconTrust key={i} icon={Icon} />
-              ))}
+              {Array.from({ length: 50 }, (_, i) => {
+                const logos = [FaGoogle, FaMicrosoft, FaAmazon, FaApple, FaFacebook]
+                const Icon = logos[i % logos.length]
+                return <IconTrust key={i} icon={Icon} />
+              })}
             </div>
           </div>
         </div>
@@ -106,7 +110,10 @@ export default function Home() {
             <EventCard img="/event4.jpg" title="Initiation DataViz" tag="Atelier" />
           </div>
           <div className="text-center mt-10">
-            <Link href="/events" className="text-dsccGreen underline hover:text-dsccOrange">Voir tous les événements →</Link>
+            <Link href="/events" className="text-dsccGreen underline hover:text-dsccOrange inline-flex items-center gap-1">
+              <span>Voir tous les événements</span>
+              <FaArrowRight />
+            </Link>
           </div>
         </div>
       </AnimatedSection>
@@ -121,7 +128,10 @@ export default function Home() {
             <ProjectCard icon="/icons/forecast.png" title="Prédiction de Ventes" />
           </div>
           <div className="text-center mt-10">
-            <Link href="/projects" className="text-dsccGreen underline hover:text-dsccOrange">Voir tous les projets →</Link>
+            <Link href="/projects" className="text-dsccGreen underline hover:text-dsccOrange inline-flex items-center gap-1">
+              <span>Voir tous les projets</span>
+              <FaArrowRight />
+            </Link>
           </div>
         </div>
       </AnimatedSection>
@@ -137,7 +147,10 @@ export default function Home() {
             <TeamCard img="/team/aya.jpg" name="Aya Karim" role="Trésorière" />
           </div>
           <div className="text-center mt-10">
-            <Link href="/team" className="text-dsccGreen underline hover:text-dsccOrange">Découvrir toute l’équipe →</Link>
+            <Link href="/team" className="text-dsccGreen underline hover:text-dsccOrange inline-flex items-center gap-1">
+              <span>Découvrir toute l’équipe</span>
+              <FaArrowRight />
+            </Link>
           </div>
         </div>
       </AnimatedSection>
@@ -206,7 +219,7 @@ function ProjectCard({ icon, title }){
 function TeamCard({ img, name, role }){
   return (
     <motion.div
-      className="text-center"
+      className="text-center shadow-md rounded-xl p-4"
       whileHover={{ scale: 1.05 }}
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}

--- a/pages/join.js
+++ b/pages/join.js
@@ -1,5 +1,6 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
+import { FaEnvelope } from 'react-icons/fa'
 
 export default function Page(){
   return (
@@ -7,7 +8,10 @@ export default function Page(){
       <AnimatedSection className="container mx-auto py-16 px-4" direction="down" delay={0.1}>
         <h1 className="text-3xl font-bold mb-6">Rejoindre le Club</h1>
         <p className="mb-4">Tu souhaites explorer la data science avec nous ? Remplis le formulaire de contact et rejoins la communauté&nbsp;!</p>
-        <a href="/contact" className="bg-dsccOrange text-white px-6 py-3 rounded">Contact</a>
+        <a href="/contact" className="bg-dsccOrange text-white px-6 py-3 rounded inline-flex items-center gap-2">
+          <span>Contact</span>
+          <FaEnvelope />
+        </a>
       </AnimatedSection>
     </Layout>
   )


### PR DESCRIPTION
## Summary
- add icons to hero buttons and call to action links
- show trust logos with infinite loop
- add icons to social links and buttons
- add subtle shadow to team cards

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a692cacb08331bba516b8f7b9d547