### PR TITLE
Adjust stats section layout

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,11 @@ export default function Home() {
         </motion.div>
       </section>
       {/* Stats */}
-      <AnimatedSection id="stats" className="py-16 bg-lightGray" direction="up">
+      <AnimatedSection
+        id="stats"
+        className="relative -mt-20 mb-16 px-4 z-20"
+        direction="up"
+      >
         <div className="mx-auto grid sm:grid-cols-2 gap-8 max-w-5xl bg-white shadow-2xl rounded-2xl px-8 py-12">
           <Stat icon={FaProjectDiagram} count={14} label="Projets réalisés" />
           <Stat icon={FaUsers} count={80} label="Membres actifs" />


### PR DESCRIPTION
## Summary
- float the stats card above the hero on the home page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6bd929e88331af03ea79d3de67d0