### PR TITLE
Add HR team section with Iyad Beddidi

### DIFF
--- a/pages/team.js
+++ b/pages/team.js
@@ -19,6 +19,21 @@ export default function Page(){
         </div>
 
         <div>
+          <h2 className="text-2xl font-semibold mb-4">Équipe RH</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+            {hrTeam.map(m => (
+              <div key={m.name} className="text-center">
+                <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
+                  <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white transition" >{m.quote}</div>
+                </div>
+                <p className="font-semibold">{m.name}</p>
+                <p className="text-sm text-gray-500">{m.role}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div>
           <h2 className="text-2xl font-semibold mb-4">Alumni & Ambassadeurs</h2>
           <p>Nos anciens membres continuent de partager leur expertise et de soutenir le club.</p>
         </div>
@@ -32,4 +47,8 @@ const members = [
   {name:'B. Khadija', role:'VP', quote:'Partage et entraide'},
   {name:'C. Yassine', role:'Trésorier', quote:'Rigueur et passion'},
   {name:'D. Salma', role:'Secrétaire', quote:'Organisation au top'},
+]
+
+const hrTeam = [
+  {name:'Iyad Beddidi', role:'Responsable RH', quote:'À votre écoute'},
 ]


### PR DESCRIPTION
## Summary
- extend team page with new "Équipe RH" section
- list Iyad Beddidi as the HR lead

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a71d368d08331a817650dd720905f