### PR TITLE
Add hero sections to pages

### DIFF
--- a/pages/contact.js
+++ b/pages/contact.js
@@ -5,6 +5,11 @@ import { FaPaperPlane, FaInstagram, FaLinkedin, FaGithub } from 'react-icons/fa'
 export default function Page(){
   return (
     <Layout title="Contact">
+      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/2.jpg)' }} />
+        <div className="absolute inset-0 bg-dsccGreen/70" />
+        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">Contact</h1>
+      </section>
       <AnimatedSection className="container mx-auto py-16 px-4 space-y-8" direction="right" delay={0.1}>
         <h1 className="text-3xl font-bold mb-6">Contact</h1>
         <form className="max-w-md space-y-4" onSubmit={e => {e.preventDefault(); alert('Message envoyé!')}}>

--- a/pages/datathonx.js
+++ b/pages/datathonx.js
@@ -5,6 +5,11 @@ import { FaPaperPlane } from 'react-icons/fa'
 export default function Page(){
   return (
     <Layout title="DatathonX">
+      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/1.jpg)' }} />
+        <div className="absolute inset-0 bg-dsccGreen/70" />
+        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">DatathonX</h1>
+      </section>
       <AnimatedSection className="container mx-auto py-16 px-4 space-y-8" direction="up" delay={0.1}>
         <h1 className="text-3xl font-bold mb-6">DatathonX – 3e édition</h1>
         <p>La compétition annuelle dédiée aux passionnés de data. Étudiants, professionnels et chercheurs sont invités à collaborer sur des problématiques concrètes.</p>

--- a/pages/events.js
+++ b/pages/events.js
@@ -4,6 +4,11 @@ import AnimatedSection from '../components/AnimatedSection'
 export default function Page(){
   return (
     <Layout title="Événements">
+      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/1.jpg)' }} />
+        <div className="absolute inset-0 bg-dsccGreen/70" />
+        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">Événements</h1>
+      </section>
       <AnimatedSection className="container mx-auto py-16 px-4 space-y-10" direction="down" delay={0.1}>
         <h1 className="text-3xl font-bold mb-6">Événements & Activités</h1>
         <div>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -4,6 +4,11 @@ import AnimatedSection from '../components/AnimatedSection'
 export default function Page(){
   return (
     <Layout title="Projets">
+      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/2.jpg)' }} />
+        <div className="absolute inset-0 bg-dsccGreen/70" />
+        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">Projets</h1>
+      </section>
       <AnimatedSection className="container mx-auto py-16 px-4" direction="left" delay={0.1}>
         <h1 className="text-3xl font-bold mb-8">Projets du Club</h1>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -4,6 +4,11 @@ import AnimatedSection from '../components/AnimatedSection'
 export default function Page(){
   return (
     <Layout title="Ressources">
+      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/1.jpg)' }} />
+        <div className="absolute inset-0 bg-dsccGreen/70" />
+        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">Ressources</h1>
+      </section>
       <AnimatedSection className="container mx-auto py-16 px-4 space-y-6" direction="right" delay={0.1}>
         <h1 className="text-3xl font-bold mb-6">Ressources</h1>
         <ul className="list-disc pl-5">

--- a/pages/team.js
+++ b/pages/team.js
@@ -4,6 +4,11 @@ import AnimatedSection from '../components/AnimatedSection'
 export default function Page(){
   return (
     <Layout title="Notre Équipe">
+      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/2.jpg)' }} />
+        <div className="absolute inset-0 bg-dsccGreen/70" />
+        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">Notre Équipe</h1>
+      </section>
       <AnimatedSection className="container mx-auto py-16 px-4 space-y-8" direction="down" delay={0.1}>
         <h1 className="text-3xl font-bold mb-6">Notre Équipe</h1>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6">


### PR DESCRIPTION
## Summary
- enhance visual consistency with hero sections on Events, Projects, DatathonX, Team, Resources and Contact pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aaacc24a083319a3278c8b21004e2