### PR TITLE
Enhance projects page style

### DIFF
--- a/pages/projects.js
+++ b/pages/projects.js
@@ -1,27 +1,56 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
+import Link from 'next/link'
+import { FaArrowRight } from 'react-icons/fa'
 
 export default function Page(){
   return (
     <Layout title="Projets">
-      <section className="relative w-full h-64 md:h-[300px] overflow-hidden flex items-center justify-center text-white">
+      {/* Hero */}
+      <section className="relative w-full h-64 md:h-[400px] overflow-hidden flex items-center justify-center text-white">
         <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/2.jpg)' }} />
-        <div className="absolute inset-0 bg-dsccGreen/70" />
-        <h1 className="relative z-10 text-4xl md:text-5xl font-extrabold">Projets</h1>
+        <div className="absolute inset-0 bg-gradient-to-r from-dsccGreen/70 to-dsccOrange/70" />
+        <div className="relative z-10 text-center px-4">
+          <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Nos projets</h1>
+          <p className="max-w-2xl mx-auto text-lg md:text-xl">
+            Découvrez quelques réalisations menées par nos membres.
+          </p>
+        </div>
       </section>
-      <AnimatedSection className="container mx-auto py-16 px-4" direction="left" delay={0.1}>
-        <h1 className="text-3xl font-bold mb-8">Projets du Club</h1>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {projects.map(p => (
-            <a key={p.name} href={p.link} className="border rounded-lg p-6 shadow hover:shadow-lg transition block">
-              <h3 className="text-xl font-semibold mb-2">{p.name}</h3>
-              <p className="text-sm mb-4">{p.desc}</p>
-              <span className="text-dsccGreen underline">GitHub</span>
-            </a>
-          ))}
+      {/* Projects */}
+      <AnimatedSection className="py-20 bg-white" direction="left">
+        <div className="container mx-auto px-4">
+          <h2 className="text-3xl font-bold mb-8 text-center">Projets du Club</h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {projects.map(p => (
+              <ProjectCard key={p.name} {...p} />
+            ))}
+          </div>
         </div>
       </AnimatedSection>
+
+      {/* Join call */}
+      <AnimatedSection className="py-20 bg-dsccGreen text-white text-center" direction="up">
+        <h2 className="text-3xl font-bold mb-4">Envie de contribuer&nbsp;?</h2>
+        <p className="mb-6 max-w-2xl mx-auto text-lg">
+          Rejoignez le club et participez au développement de projets innovants.
+        </p>
+        <Link href="/join" className="bg-white text-dsccGreen hover:bg-dsccOrange hover:text-white px-6 py-3 rounded inline-flex items-center gap-2 transition">
+          <span>Rejoindre le club</span>
+          <FaArrowRight />
+        </Link>
+      </AnimatedSection>
     </Layout>
+  )
+}
+
+function ProjectCard({ name, link, desc }) {
+  return (
+    <a href={link} className="border rounded-lg p-6 shadow hover:shadow-lg transition block">
+      <h3 className="text-xl font-semibold mb-2">{name}</h3>
+      <p className="text-sm mb-4">{desc}</p>
+      <span className="text-dsccGreen underline">GitHub</span>
+    </a>
   )
 }
 


### PR DESCRIPTION
## Summary
- restyle hero section of the projects page
- display projects in an animated section
- add call-to-action section to join the club

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab1d6dd1483319cd25487e2926251