### PR TITLE
Add curated resource links

### DIFF
--- a/pages/resources.js
+++ b/pages/resources.js
@@ -16,23 +16,45 @@ export default function Page() {
         </div>
       </section>
 
-      {/* Docs */}
+      {/* Resources */}
       <AnimatedSection className="py-20 bg-white" direction="left">
-        <div className="container mx-auto px-4 space-y-8">
+        <div className="container mx-auto px-4 space-y-12">
           <div>
-            <h2 className="text-2xl font-semibold mb-2">Documents publics</h2>
-            <ul className="list-disc pl-5">
-              <li><a href="/smartnews360.pdf" className="text-dsccGreen underline">Rapport SmartNews360</a></li>
-              <li><a href="/datathonx-roadmap.pdf" className="text-dsccGreen underline">Feuille de route DatathonX</a></li>
+            <h2 className="text-3xl font-bold mb-8 text-center">Ressources pédagogiques</h2>
+            <div className="grid md:grid-cols-2 gap-8">
+              <div>
+                <h3 className="text-xl font-semibold mb-2">Cours et leçons</h3>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li><a href="https://drive.google.com/intro-python" className="text-dsccGreen underline">Introduction à Python (PDF)</a></li>
+                  <li><a href="https://drive.google.com/ml-basics" className="text-dsccGreen underline">Machine Learning Basics (slides)</a></li>
+                  <li><a href="https://drive.google.com/dataviz" className="text-dsccGreen underline">Atelier DataViz</a></li>
+                </ul>
+              </div>
+              <div>
+                <h3 className="text-xl font-semibold mb-2">Programmes & codes</h3>
+                <ul className="list-disc pl-5 space-y-1">
+                  <li><a href="https://drive.google.com/python-scripts" className="text-dsccGreen underline">Scripts d'exemple Python</a></li>
+                  <li><a href="https://drive.google.com/notebooks" className="text-dsccGreen underline">Notebooks Jupyter</a></li>
+                  <li><a href="https://drive.google.com/dataviz-tableau" className="text-dsccGreen underline">Projet DataViz Tableau</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+          <div>
+            <h2 className="text-3xl font-bold mb-8 text-center">Outils recommandés</h2>
+            <ul className="list-disc pl-5 max-w-xl mx-auto space-y-1">
+              <li><a href="https://www.python.org/downloads/" className="text-dsccGreen underline">Python</a></li>
+              <li><a href="https://code.visualstudio.com/" className="text-dsccGreen underline">Visual Studio Code</a></li>
+              <li><a href="https://jupyter.org/install" className="text-dsccGreen underline">Jupyter Notebook</a></li>
             </ul>
           </div>
-          <div>
-            <h2 className="text-2xl font-semibold mb-2">Tutoriels</h2>
-            <p>Retrouvez nos guides pas-à-pas réalisés par les membres du club.</p>
-          </div>
-          <div>
-            <h2 className="text-2xl font-semibold mb-2">Documents internes</h2>
-            <p>Accès réservé aux membres.</p>
+          <div className="text-center">
+            <h2 className="text-3xl font-bold mb-4">Accès au Drive du Club</h2>
+            <p className="mb-6 max-w-2xl mx-auto text-lg">Retrouvez toutes nos ressources partagées sur Google Drive.</p>
+            <a href="https://drive.google.com/dscc" className="bg-dsccOrange text-white px-6 py-3 rounded inline-flex items-center gap-2 transition hover:bg-dsccGreen">
+              <span>Ouvrir le Drive</span>
+              <FaArrowRight />
+            </a>
           </div>
         </div>
       </AnimatedSection>


### PR DESCRIPTION
## Summary
- expand *resources* page to include example course materials, code samples, recommended tools and a link to the shared Google Drive

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab75c1c548331b7cf3c2bd212093b