### PR TITLE
Add admin login and dashboard

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -19,6 +19,7 @@ export default function Header(){
           <Link href="/datathonx" className="hover:text-dsccGreen transition">DatathonX</Link>
           <Link href="/team" className="hover:text-dsccGreen transition">Équipe</Link>
           <Link href="/resources" className="hover:text-dsccGreen transition">Ressources</Link>
+          <Link href="/admin1" className="hover:text-dsccGreen transition">Admin</Link>
           <Link href="/contact" className="flex items-center bg-dsccOrange text-white px-4 py-2 rounded hover:opacity-90 transition">
             <span>Contact</span>
             <FaEnvelope className="ml-1" />

--- a/pages/admin1/dashboard.js
+++ b/pages/admin1/dashboard.js
@@ -1,0 +1,83 @@
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/router'
+import Layout from '../../components/Layout'
+
+export default function Dashboard() {
+  const router = useRouter()
+  const [projects, setProjects] = useState([])
+  const [name, setName] = useState('')
+  const [link, setLink] = useState('')
+  const [desc, setDesc] = useState('')
+
+  useEffect(() => {
+    const loggedIn = typeof window !== 'undefined' && localStorage.getItem('loggedIn')
+    if (!loggedIn) {
+      router.push('/admin1')
+    } else {
+      const stored = localStorage.getItem('customProjects')
+      if (stored) setProjects(JSON.parse(stored))
+    }
+  }, [router])
+
+  const addProject = (e) => {
+    e.preventDefault()
+    const newProj = { name, link, desc }
+    const updated = [...projects, newProj]
+    setProjects(updated)
+    localStorage.setItem('customProjects', JSON.stringify(updated))
+    setName('')
+    setLink('')
+    setDesc('')
+  }
+
+  const logout = () => {
+    localStorage.removeItem('loggedIn')
+    router.push('/admin1')
+  }
+
+  return (
+    <Layout title="Dashboard">
+      <section className="py-20 container mx-auto px-4">
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-3xl font-bold">Dashboard</h1>
+          <button onClick={logout} className="text-red-500 underline">Logout</button>
+        </div>
+        <form onSubmit={addProject} className="space-y-4 mb-10 max-w-md">
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Project name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="GitHub link"
+            value={link}
+            onChange={(e) => setLink(e.target.value)}
+            required
+          />
+          <textarea
+            className="border p-2 w-full rounded"
+            placeholder="Description"
+            value={desc}
+            onChange={(e) => setDesc(e.target.value)}
+            required
+          />
+          <button type="submit" className="bg-dsccGreen text-white px-4 py-2 rounded w-full">Add Project</button>
+        </form>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {projects.map((p, i) => (
+            <div key={i} className="border rounded p-4">
+              <h3 className="font-semibold">{p.name}</h3>
+              <p className="text-sm mb-2">{p.desc}</p>
+              <a href={p.link} className="text-dsccGreen underline">GitHub</a>
+            </div>
+          ))}
+        </div>
+      </section>
+    </Layout>
+  )
+}

--- a/pages/admin1/index.js
+++ b/pages/admin1/index.js
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import Layout from '../../components/Layout'
+
+export default function AdminLogin() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (username === 'admin' && password === 'admin') {
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('loggedIn', 'true')
+      }
+      router.push('/admin1/dashboard')
+    } else {
+      setError('Invalid credentials')
+    }
+  }
+
+  return (
+    <Layout title="Admin Login">
+      <section className="flex flex-col items-center justify-center py-20">
+        <h1 className="text-3xl font-bold mb-6">Admin Login</h1>
+        <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+          {error && <p className="text-red-500">{error}</p>}
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <input
+            className="border p-2 w-full rounded"
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            type="submit"
+            className="bg-dsccGreen text-white px-4 py-2 rounded w-full"
+          >
+            Login
+          </button>
+        </form>
+      </section>
+    </Layout>
+  )
+}

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -2,8 +2,18 @@ import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
 import Link from 'next/link'
 import { FaArrowRight } from 'react-icons/fa'
+import { useState, useEffect } from 'react'
 
 export default function Page(){
+  const [customProjects, setCustomProjects] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('customProjects')
+    if (stored) setCustomProjects(JSON.parse(stored))
+  }, [])
+
+  const allProjects = [...projects, ...customProjects]
+
   return (
     <Layout title="Projets">
       {/* Hero */}
@@ -22,8 +32,8 @@ export default function Page(){
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Projets du Club</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {projects.map(p => (
-              <ProjectCard key={p.name} {...p} />
+            {allProjects.map((p, idx) => (
+              <ProjectCard key={idx} {...p} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add link to the new admin section in the header
- create `/admin1` login page using default credentials
- add a simple dashboard to create projects
- display user-added projects on the public projects page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ab928ee788331bc26fd5990c50198