### PR TITLE
Remove header admin link and extend dashboard

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -19,7 +19,6 @@ export default function Header(){
           <Link href="/datathonx" className="hover:text-dsccGreen transition">DatathonX</Link>
           <Link href="/team" className="hover:text-dsccGreen transition">Équipe</Link>
           <Link href="/resources" className="hover:text-dsccGreen transition">Ressources</Link>
-          <Link href="/admin1" className="hover:text-dsccGreen transition">Admin</Link>
           <Link href="/contact" className="flex items-center bg-dsccOrange text-white px-4 py-2 rounded hover:opacity-90 transition">
             <span>Contact</span>
             <FaEnvelope className="ml-1" />

--- a/pages/admin1/dashboard.js
+++ b/pages/admin1/dashboard.js
@@ -5,17 +5,23 @@ import Layout from '../../components/Layout'
 export default function Dashboard() {
   const router = useRouter()
   const [projects, setProjects] = useState([])
+  const [events, setEvents] = useState([])
   const [name, setName] = useState('')
   const [link, setLink] = useState('')
   const [desc, setDesc] = useState('')
+  const [evtTitle, setEvtTitle] = useState('')
+  const [evtDate, setEvtDate] = useState('')
+  const [evtLocation, setEvtLocation] = useState('')
 
   useEffect(() => {
     const loggedIn = typeof window !== 'undefined' && localStorage.getItem('loggedIn')
     if (!loggedIn) {
       router.push('/admin1')
     } else {
-      const stored = localStorage.getItem('customProjects')
-      if (stored) setProjects(JSON.parse(stored))
+      const storedProjects = localStorage.getItem('customProjects')
+      if (storedProjects) setProjects(JSON.parse(storedProjects))
+      const storedEvents = localStorage.getItem('customEvents')
+      if (storedEvents) setEvents(JSON.parse(storedEvents))
     }
   }, [router])
 
@@ -30,6 +36,29 @@ export default function Dashboard() {
     setDesc('')
   }
 
+  const addEvent = (e) => {
+    e.preventDefault()
+    const newEvt = { title: evtTitle, date: evtDate, location: evtLocation }
+    const updated = [...events, newEvt]
+    setEvents(updated)
+    localStorage.setItem('customEvents', JSON.stringify(updated))
+    setEvtTitle('')
+    setEvtDate('')
+    setEvtLocation('')
+  }
+
+  const removeProject = (index) => {
+    const updated = projects.filter((_, i) => i !== index)
+    setProjects(updated)
+    localStorage.setItem('customProjects', JSON.stringify(updated))
+  }
+
+  const removeEvent = (index) => {
+    const updated = events.filter((_, i) => i !== index)
+    setEvents(updated)
+    localStorage.setItem('customEvents', JSON.stringify(updated))
+  }
+
   const logout = () => {
     localStorage.removeItem('loggedIn')
     router.push('/admin1')
@@ -42,6 +71,7 @@ export default function Dashboard() {
           <h1 className="text-3xl font-bold">Dashboard</h1>
           <button onClick={logout} className="text-red-500 underline">Logout</button>
         </div>
+        <h2 className="text-2xl font-semibold mb-4">Ajouter un projet</h2>
         <form onSubmit={addProject} className="space-y-4 mb-10 max-w-md">
           <input
             className="border p-2 w-full rounded"
@@ -68,12 +98,51 @@ export default function Dashboard() {
           />
           <button type="submit" className="bg-dsccGreen text-white px-4 py-2 rounded w-full">Add Project</button>
         </form>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
           {projects.map((p, i) => (
             <div key={i} className="border rounded p-4">
               <h3 className="font-semibold">{p.name}</h3>
               <p className="text-sm mb-2">{p.desc}</p>
-              <a href={p.link} className="text-dsccGreen underline">GitHub</a>
+              <a href={p.link} className="text-dsccGreen underline block mb-2">GitHub</a>
+              <button onClick={() => removeProject(i)} className="text-red-500 text-sm underline">Remove</button>
+            </div>
+          ))}
+        </div>
+
+        <h2 className="text-2xl font-semibold mb-4">Ajouter un rendez-vous</h2>
+        <form onSubmit={addEvent} className="space-y-4 mb-10 max-w-md">
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Titre"
+            value={evtTitle}
+            onChange={(e) => setEvtTitle(e.target.value)}
+            required
+          />
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Date"
+            value={evtDate}
+            onChange={(e) => setEvtDate(e.target.value)}
+            required
+          />
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Lieu"
+            value={evtLocation}
+            onChange={(e) => setEvtLocation(e.target.value)}
+            required
+          />
+          <button type="submit" className="bg-dsccGreen text-white px-4 py-2 rounded w-full">Add Event</button>
+        </form>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {events.map((e, i) => (
+            <div key={i} className="border rounded p-4">
+              <h3 className="font-semibold">{e.title}</h3>
+              <p className="text-sm mb-2">{e.date} – {e.location}</p>
+              <button onClick={() => removeEvent(i)} className="text-red-500 text-sm underline">Remove</button>
             </div>
           ))}
         </div>

--- a/pages/events.js
+++ b/pages/events.js
@@ -3,6 +3,7 @@ import AnimatedSection from '../components/AnimatedSection'
 import Counter from '../components/Counter'
 import ImageSlider from '../components/ImageSlider'
 import Link from 'next/link'
+import { useState, useEffect } from 'react'
 import {
   FaRegCalendarAlt,
   FaUsers,
@@ -12,11 +13,19 @@ import {
 } from 'react-icons/fa'
 
 export default function Page() {
+  const [customEvents, setCustomEvents] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('customEvents')
+    if (stored) setCustomEvents(JSON.parse(stored))
+  }, [])
+
   const upcoming = [
     { title: 'Atelier Python avancé', date: '15 juin 2024', location: 'Salle 101' },
     { title: 'Conférence IA éthique', date: '28 juin 2024', location: 'Amphi A' },
     { title: 'Hackathon Data4Good', date: '10 juillet 2024', location: 'ENSA' }
   ]
+  const allEvents = [...upcoming, ...customEvents]
   const images = ['/1.jpg', '/2.jpg', '/IMG-20250215-WA0007.jpg']
   return (
     <Layout title="Événements">
@@ -50,7 +59,7 @@ export default function Page() {
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Prochains rendez-vous</h2>
           <div className="space-y-6 max-w-3xl mx-auto">
-            {upcoming.map((e, i) => (
+            {allEvents.map((e, i) => (
               <div key={i} className="p-4 bg-white rounded shadow">
                 <h3 className="text-xl font-semibold flex items-center gap-2">
                   <FaRegCalendarAlt className="text-dsccOrange" /> {e.title}


### PR DESCRIPTION
## Summary
- hide the Admin link in the header navigation
- display stored events on the events page
- allow managing projects and upcoming meetings in the admin dashboard

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abab7ed2883318db04c69a1362840