### PR TITLE
Refine resources UI and remove dark mode toggle

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import { useState } from 'react'
-import DarkModeToggle from './DarkModeToggle'
 import { FaEnvelope, FaBars, FaTimes } from 'react-icons/fa'
 
 export default function Header(){
@@ -36,7 +35,6 @@ export default function Header(){
             <span>Contact</span>
             <FaEnvelope className="ml-1" />
           </Link>
-          <DarkModeToggle />
         </nav>
       </div>
     </header>

--- a/pages/admin1/dashboard.js
+++ b/pages/admin1/dashboard.js
@@ -6,12 +6,15 @@ export default function Dashboard() {
   const router = useRouter()
   const [projects, setProjects] = useState([])
   const [events, setEvents] = useState([])
+  const [drives, setDrives] = useState([])
   const [name, setName] = useState('')
   const [link, setLink] = useState('')
   const [desc, setDesc] = useState('')
   const [evtTitle, setEvtTitle] = useState('')
   const [evtDate, setEvtDate] = useState('')
   const [evtLocation, setEvtLocation] = useState('')
+  const [driveTitle, setDriveTitle] = useState('')
+  const [driveLink, setDriveLink] = useState('')
 
   useEffect(() => {
     const loggedIn = typeof window !== 'undefined' && localStorage.getItem('loggedIn')
@@ -22,6 +25,8 @@ export default function Dashboard() {
       if (storedProjects) setProjects(JSON.parse(storedProjects))
       const storedEvents = localStorage.getItem('customEvents')
       if (storedEvents) setEvents(JSON.parse(storedEvents))
+      const storedDrives = localStorage.getItem('customDrives')
+      if (storedDrives) setDrives(JSON.parse(storedDrives))
     }
   }, [router])
 
@@ -47,6 +52,16 @@ export default function Dashboard() {
     setEvtLocation('')
   }
 
+  const addDrive = (e) => {
+    e.preventDefault()
+    const newDrive = { title: driveTitle, link: driveLink }
+    const updated = [...drives, newDrive]
+    setDrives(updated)
+    localStorage.setItem('customDrives', JSON.stringify(updated))
+    setDriveTitle('')
+    setDriveLink('')
+  }
+
   const removeProject = (index) => {
     const updated = projects.filter((_, i) => i !== index)
     setProjects(updated)
@@ -57,6 +72,12 @@ export default function Dashboard() {
     const updated = events.filter((_, i) => i !== index)
     setEvents(updated)
     localStorage.setItem('customEvents', JSON.stringify(updated))
+  }
+
+  const removeDrive = (index) => {
+    const updated = drives.filter((_, i) => i !== index)
+    setDrives(updated)
+    localStorage.setItem('customDrives', JSON.stringify(updated))
   }
 
   const logout = () => {
@@ -143,6 +164,35 @@ export default function Dashboard() {
               <h3 className="font-semibold">{e.title}</h3>
               <p className="text-sm mb-2">{e.date} – {e.location}</p>
               <button onClick={() => removeEvent(i)} className="text-red-500 text-sm underline">Remove</button>
+            </div>
+          ))}
+        </div>
+
+        <h2 className="text-2xl font-semibold my-4">Ajouter un Drive</h2>
+        <form onSubmit={addDrive} className="space-y-4 mb-10 max-w-md">
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Titre du Drive"
+            value={driveTitle}
+            onChange={(e) => setDriveTitle(e.target.value)}
+            required
+          />
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Lien"
+            value={driveLink}
+            onChange={(e) => setDriveLink(e.target.value)}
+            required
+          />
+          <button type="submit" className="bg-dsccGreen text-white px-4 py-2 rounded w-full">Add Drive</button>
+        </form>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+          {drives.map((d, i) => (
+            <div key={i} className="border rounded p-4 flex justify-between items-center">
+              <a href={d.link} className="text-dsccGreen underline">{d.title}</a>
+              <button onClick={() => removeDrive(i)} className="text-red-500 text-sm underline">Remove</button>
             </div>
           ))}
         </div>

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -2,8 +2,20 @@ import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
 import Link from 'next/link'
 import { FaArrowRight } from 'react-icons/fa'
+import { useState, useEffect } from 'react'
 
 export default function Page() {
+  const [driveLinks, setDriveLinks] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('customDrives')
+    if (stored) setDriveLinks(JSON.parse(stored))
+  }, [])
+
+  const defaultDrives = [
+    { title: 'Drive principal', link: 'https://drive.google.com/dscc' }
+  ]
+  const allDrives = [...defaultDrives, ...driveLinks]
   return (
     <Layout title="Ressources">
       {/* Hero */}
@@ -12,49 +24,36 @@ export default function Page() {
         <div className="absolute inset-0 bg-gradient-to-r from-dsccGreen/70 to-dsccOrange/70" />
         <div className="relative z-10 text-center px-4">
           <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Ressources</h1>
-          <p className="max-w-2xl mx-auto text-lg md:text-xl">Guides pratiques et documents à disposition de la communauté.</p>
+          <p className="max-w-2xl mx-auto text-lg md:text-xl">Accédez directement à nos documents partagés sur Google Drive.</p>
         </div>
       </section>
 
       {/* Resources */}
       <AnimatedSection className="py-20 bg-white" direction="left">
-        <div className="container mx-auto px-4 space-y-12">
-          <div>
-            <h2 className="text-3xl font-bold mb-8 text-center">Ressources pédagogiques</h2>
-            <div className="grid md:grid-cols-2 gap-8">
-              <div>
-                <h3 className="text-xl font-semibold mb-2">Cours et leçons</h3>
-                <ul className="list-disc pl-5 space-y-1">
-                  <li><a href="https://drive.google.com/intro-python" className="text-dsccGreen underline">Introduction à Python (PDF)</a></li>
-                  <li><a href="https://drive.google.com/ml-basics" className="text-dsccGreen underline">Machine Learning Basics (slides)</a></li>
-                  <li><a href="https://drive.google.com/dataviz" className="text-dsccGreen underline">Atelier DataViz</a></li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="text-xl font-semibold mb-2">Programmes & codes</h3>
-                <ul className="list-disc pl-5 space-y-1">
-                  <li><a href="https://drive.google.com/python-scripts" className="text-dsccGreen underline">Scripts d'exemple Python</a></li>
-                  <li><a href="https://drive.google.com/notebooks" className="text-dsccGreen underline">Notebooks Jupyter</a></li>
-                  <li><a href="https://drive.google.com/dataviz-tableau" className="text-dsccGreen underline">Projet DataViz Tableau</a></li>
-                </ul>
-              </div>
+        <div className="container mx-auto px-4">
+          <div className="grid md:grid-cols-2 gap-12 items-center">
+            <div>
+              <h2 className="text-3xl font-bold mb-4 text-center md:text-left">Outils recommandés</h2>
+              <ul className="list-disc pl-5 space-y-1 max-w-md mx-auto md:mx-0">
+                <li><a href="https://www.python.org/downloads/" className="text-dsccGreen underline">Python</a></li>
+                <li><a href="https://code.visualstudio.com/" className="text-dsccGreen underline">Visual Studio Code</a></li>
+                <li><a href="https://jupyter.org/install" className="text-dsccGreen underline">Jupyter Notebook</a></li>
+              </ul>
             </div>
-          </div>
-          <div>
-            <h2 className="text-3xl font-bold mb-8 text-center">Outils recommandés</h2>
-            <ul className="list-disc pl-5 max-w-xl mx-auto space-y-1">
-              <li><a href="https://www.python.org/downloads/" className="text-dsccGreen underline">Python</a></li>
-              <li><a href="https://code.visualstudio.com/" className="text-dsccGreen underline">Visual Studio Code</a></li>
-              <li><a href="https://jupyter.org/install" className="text-dsccGreen underline">Jupyter Notebook</a></li>
-            </ul>
-          </div>
-          <div className="text-center">
-            <h2 className="text-3xl font-bold mb-4">Accès au Drive du Club</h2>
-            <p className="mb-6 max-w-2xl mx-auto text-lg">Retrouvez toutes nos ressources partagées sur Google Drive.</p>
-            <a href="https://drive.google.com/dscc" className="bg-dsccOrange text-white px-6 py-3 rounded inline-flex items-center gap-2 transition hover:bg-dsccGreen">
-              <span>Ouvrir le Drive</span>
-              <FaArrowRight />
-            </a>
+            <div className="bg-dsccGreen/5 p-8 rounded-lg text-center">
+              <h2 className="text-3xl font-bold mb-4">Accès aux Drives du Club</h2>
+              <p className="mb-6">Retrouvez toutes nos ressources partagées sur Google Drive.</p>
+              <ul className="space-y-2">
+                {allDrives.map((d, i) => (
+                  <li key={i}>
+                    <a href={d.link} className="text-dsccGreen underline inline-flex items-center gap-2">
+                      <span>{d.title}</span>
+                      <FaArrowRight />
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
           </div>
         </div>
       </AnimatedSection>


### PR DESCRIPTION
## Summary
- drop dark mode toggle from header
- simplify resources page and show drives from admin dashboard
- add drive management form to the admin dashboard

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ac70c0b348331af1585630f7d164d