### PR TITLE
Add laureats section and dashboard management

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -30,6 +30,7 @@ export default function Header(){
           <Link href="/projects" className="hover:text-dsccGreen transition whitespace-nowrap">Projets</Link>
           <Link href="/datathonx" className="hover:text-dsccGreen transition whitespace-nowrap">DatathonX</Link>
           <Link href="/team" className="hover:text-dsccGreen transition whitespace-nowrap">Équipe</Link>
+          <Link href="/laureats" className="hover:text-dsccGreen transition whitespace-nowrap">Laurats</Link>
           <Link href="/resources" className="hover:text-dsccGreen transition whitespace-nowrap">Ressources</Link>
           <Link href="/contact" className="flex items-center bg-dsccOrange text-white px-4 py-2 rounded hover:opacity-90 transition whitespace-nowrap">
             <span>Contact</span>

--- a/pages/admin1/dashboard.js
+++ b/pages/admin1/dashboard.js
@@ -7,6 +7,9 @@ export default function Dashboard() {
   const [projects, setProjects] = useState([])
   const [events, setEvents] = useState([])
   const [drives, setDrives] = useState([])
+  const [laureats, setLaureats] = useState([])
+  const [laureatName, setLaureatName] = useState('')
+  const [laureatLinkedIn, setLaureatLinkedIn] = useState('')
   const [name, setName] = useState('')
   const [link, setLink] = useState('')
   const [desc, setDesc] = useState('')
@@ -27,6 +30,8 @@ export default function Dashboard() {
       if (storedEvents) setEvents(JSON.parse(storedEvents))
       const storedDrives = localStorage.getItem('customDrives')
       if (storedDrives) setDrives(JSON.parse(storedDrives))
+      const storedLaureats = localStorage.getItem('customLaureats')
+      if (storedLaureats) setLaureats(JSON.parse(storedLaureats))
     }
   }, [router])
 
@@ -62,6 +67,16 @@ export default function Dashboard() {
     setDriveLink('')
   }
 
+  const addLaureat = (e) => {
+    e.preventDefault()
+    const newL = { name: laureatName, linkedin: laureatLinkedIn }
+    const updated = [...laureats, newL]
+    setLaureats(updated)
+    localStorage.setItem('customLaureats', JSON.stringify(updated))
+    setLaureatName('')
+    setLaureatLinkedIn('')
+  }
+
   const removeProject = (index) => {
     const updated = projects.filter((_, i) => i !== index)
     setProjects(updated)
@@ -78,6 +93,12 @@ export default function Dashboard() {
     const updated = drives.filter((_, i) => i !== index)
     setDrives(updated)
     localStorage.setItem('customDrives', JSON.stringify(updated))
+  }
+
+  const removeLaureat = (index) => {
+    const updated = laureats.filter((_, i) => i !== index)
+    setLaureats(updated)
+    localStorage.setItem('customLaureats', JSON.stringify(updated))
   }
 
   const logout = () => {
@@ -193,6 +214,35 @@ export default function Dashboard() {
             <div key={i} className="border rounded p-4 flex justify-between items-center">
               <a href={d.link} className="text-dsccGreen underline">{d.title}</a>
               <button onClick={() => removeDrive(i)} className="text-red-500 text-sm underline">Remove</button>
+            </div>
+          ))}
+        </div>
+
+        <h2 className="text-2xl font-semibold my-4">Ajouter un Lauréat</h2>
+        <form onSubmit={addLaureat} className="space-y-4 mb-10 max-w-md">
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Nom"
+            value={laureatName}
+            onChange={(e) => setLaureatName(e.target.value)}
+            required
+          />
+          <input
+            className="border p-2 w-full rounded"
+            type="text"
+            placeholder="Lien LinkedIn"
+            value={laureatLinkedIn}
+            onChange={(e) => setLaureatLinkedIn(e.target.value)}
+            required
+          />
+          <button type="submit" className="bg-dsccGreen text-white px-4 py-2 rounded w-full">Add Laureat</button>
+        </form>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-12">
+          {laureats.map((l, i) => (
+            <div key={i} className="border rounded p-4 flex justify-between items-center">
+              <a href={l.linkedin} className="text-dsccGreen underline">{l.name}</a>
+              <button onClick={() => removeLaureat(i)} className="text-red-500 text-sm underline">Remove</button>
             </div>
           ))}
         </div>

--- a/pages/laureats.js
+++ b/pages/laureats.js
@@ -1,0 +1,50 @@
+import Layout from '../components/Layout'
+import AnimatedSection from '../components/AnimatedSection'
+import { useState, useEffect } from 'react'
+
+export default function Page(){
+  const [customLaureats, setCustomLaureats] = useState([])
+
+  useEffect(() => {
+    const stored = localStorage.getItem('customLaureats')
+    if (stored) setCustomLaureats(JSON.parse(stored))
+  }, [])
+
+  const laureats = [...defaultLaureats, ...customLaureats]
+
+  return (
+    <Layout title="Laureats">
+      {/* Hero */}
+      <section className="relative w-full h-64 md:h-[400px] overflow-hidden flex items-center justify-center text-white">
+        <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/1.jpg)' }} />
+        <div className="absolute inset-0 bg-gradient-to-r from-dsccGreen/70 to-dsccOrange/70" />
+        <div className="relative z-10 text-center px-4">
+          <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Nos lauréats</h1>
+          <p className="max-w-2xl mx-auto text-lg md:text-xl">Ils ont marqué l\'histoire du club.</p>
+        </div>
+      </section>
+      {/* Laureats */}
+      <AnimatedSection className="py-20 bg-white" direction="left">
+        <div className="container mx-auto px-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+            {laureats.map((l, i) => (
+              <div key={i} className="text-center">
+                <img
+                  src={`https://unavatar.io/${encodeURIComponent(l.linkedin)}`}
+                  alt={l.name}
+                  className="w-24 h-24 rounded-full mx-auto mb-2 object-cover"
+                />
+                <p className="font-semibold">{l.name}</p>
+                <a href={l.linkedin} className="text-sm text-dsccGreen underline" target="_blank" rel="noopener noreferrer">
+                  LinkedIn
+                </a>
+              </div>
+            ))}
+          </div>
+        </div>
+      </AnimatedSection>
+    </Layout>
+  )
+}
+
+const defaultLaureats = []


### PR DESCRIPTION
## Summary
- create laureats page with hero and avatars loaded from LinkedIn via unavatar
- link laureats page in the header navigation
- extend admin dashboard to add/manage laureats stored in localStorage

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acbc716b883318bc033f1c17d4be5