### PR TITLE
Remove laureate profile images

### DIFF
--- a/pages/resources.js
+++ b/pages/resources.js
@@ -91,19 +91,14 @@ export default function Page() {
 function LaureatCard({ name, linkedin }) {
   return (
     <div className="border rounded-lg p-6 shadow hover:shadow-lg transition flex flex-col items-center bg-white text-center">
-      <img
-        src={`https://unavatar.io/${encodeURIComponent(linkedin)}`}
-        alt={name}
-        className="w-24 h-24 rounded-full mb-4 object-cover"
-      />
+      <p className="font-semibold mb-4">{name}</p>
       <a
         href={linkedin}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-dsccGreen hover:text-dsccOrange flex items-center gap-1 text-sm mt-auto"
+        className="text-dsccGreen hover:text-dsccOrange text-3xl mt-auto"
       >
         <FaLinkedin />
-        <span>{name}</span>
       </a>
     </div>
   )


### PR DESCRIPTION
## Summary
- remove avatar images from laureate cards
- display the laureate name above a single LinkedIn icon

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad09344708331bc006657e28f7524