### PR TITLE
Update logo and sponsor animation

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -10,7 +10,7 @@ export default function Header(){
       <div className="container mx-auto flex items-center justify-between p-4 relative">
         <Link href="/">
           <span className="flex items-center gap-2 cursor-pointer">
-            <Image src="/logopng.png" alt="DSCC logo" width={80} height={80} className="bg-transparent" />
+            <Image src="/logopng.png" alt="DSCC logo" width={65} height={65} className="bg-transparent" />
           </span>
         </Link>
         <button

--- a/pages/index.js
+++ b/pages/index.js
@@ -57,7 +57,6 @@ export default function Home() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 1 }}
         >
-          <Image src="/logopng.png" alt="DSCC logo" width={120} height={120} className="mx-auto mb-6" />
           <h1 className="text-4xl md:text-6xl font-extrabold mb-6">L’innovation par la donnée</h1>
           <p className="max-w-xl mx-auto text-lg md:text-xl mb-8">
             Le Club Data Science de l’ENSA s’engage à promouvoir l’apprentissage,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,7 +16,7 @@ body {
 }
 
   .slide-right {
-    animation: slideRight 20s linear infinite;
+    animation: slideRight 40s linear infinite;
   }
 
 @keyframes slideLeft {
@@ -25,7 +25,7 @@ body {
 }
 
   .slide-left {
-    animation: slideLeft 20s linear infinite;
+    animation: slideLeft 40s linear infinite;
   }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- shrink header logo to 65px
- remove logo from the hero slideshow
- slow down sliding animations for sponsors

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad8b2757883318462f847b51dd523