### PR TITLE
Update sponsors speed and add event images

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -62,7 +62,7 @@ export default function Page() {
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold text-center mb-8">Ils nous font confiance</h2>
           <div className="overflow-hidden">
-            <div className="flex flex-nowrap items-center gap-10 w-max slide-left">
+            <div className="flex flex-nowrap items-center gap-10 w-max sponsor-scroll">
               {Array.from({ length: 20 }, (_, i) => {
                 const logos = [
                   '/sponsors/1631326041576.jfif',
@@ -89,7 +89,7 @@ export default function Page() {
       <AnimatedSection className="py-20 bg-lightGray" direction="left">
         <div className="container mx-auto px-4 space-y-24">
           <div className="grid md:grid-cols-2 gap-8 items-center">
-            <Image src="/2.jpg" alt="mission" width={600} height={400} className="rounded-lg shadow" />
+            <Image src="/1.jpg" alt="mission" width={600} height={400} className="rounded-lg shadow" />
             <div className="text-center md:text-left">
               <h2 className="text-3xl font-bold mb-4 flex items-center justify-center md:justify-start gap-2">
                 <FaBullseye /> Notre mission
@@ -130,7 +130,19 @@ export default function Page() {
             projets et des événements pour devenir aujourd'hui une communauté
             active et soudée.
           </p>
-          <ImageSlider images={['/1.jpg','/2.jpg','/IMG-20250215-WA0007.jpg']} />
+          <ImageSlider
+            images={[
+              '/event/Screenshot 2025-07-06 212003.png',
+              '/event/Screenshot 2025-07-06 212023.png',
+              '/event/Screenshot 2025-07-06 212041.png',
+              '/event/Screenshot 2025-07-06 212101.png',
+              '/event/Screenshot 2025-07-06 212116.png',
+              '/event/Screenshot 2025-07-06 212130.png',
+              '/1.jpg',
+              '/2.jpg',
+              '/IMG-20250215-WA0007.jpg'
+            ]}
+          />
           <Timeline />
         </div>
       </AnimatedSection>

--- a/pages/datathonx.js
+++ b/pages/datathonx.js
@@ -93,7 +93,11 @@ export default function Page() {
           <div className="grid gap-6 sm:grid-cols-3">
             {winners.map((w, i) => (
               <div key={i} className="bg-lightGray p-4 rounded shadow text-center">
-                <img src={w.img} alt={`winner ${i+1}`} className="h-40 w-full object-cover rounded mb-4" />
+                <img
+                  src={w.img}
+                  alt={`winner ${i + 1}`}
+                  className="h-40 w-full object-cover object-top rounded mb-4"
+                />
                 <p className="font-semibold text-lg">{w.prize}</p>
               </div>
             ))}

--- a/pages/events.js
+++ b/pages/events.js
@@ -26,7 +26,17 @@ export default function Page() {
     { title: 'Hackathon Data4Good', date: '10 juillet 2024', location: 'ENSA' }
   ]
   const allEvents = [...upcoming, ...customEvents]
-  const images = ['/1.jpg', '/2.jpg', '/IMG-20250215-WA0007.jpg']
+  const images = [
+    '/event/Screenshot 2025-07-06 212003.png',
+    '/event/Screenshot 2025-07-06 212023.png',
+    '/event/Screenshot 2025-07-06 212041.png',
+    '/event/Screenshot 2025-07-06 212101.png',
+    '/event/Screenshot 2025-07-06 212116.png',
+    '/event/Screenshot 2025-07-06 212130.png',
+    '/1.jpg',
+    '/2.jpg',
+    '/IMG-20250215-WA0007.jpg'
+  ]
   return (
     <Layout title="Événements">
       {/* Hero */}

--- a/pages/index.js
+++ b/pages/index.js
@@ -91,7 +91,7 @@ export default function Home() {
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold text-center mb-8">Ils nous font confiance</h2>
           <div className="overflow-hidden">
-            <div className="flex flex-nowrap items-center gap-10 w-max slide-left">
+            <div className="flex flex-nowrap items-center gap-10 w-max sponsor-scroll">
               {Array.from({ length: 50 }, (_, i) => {
                 const logos = [
                   '/sponsors/1631326041576.jfif',

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -28,6 +28,11 @@ body {
     animation: slideLeft 40s linear infinite;
   }
 
+  /* Faster scrolling for sponsor logos */
+  .sponsor-scroll {
+    animation: slideLeft 20s linear infinite;
+  }
+
 @layer utilities {
   .masonry {
     column-gap: 1rem;


### PR DESCRIPTION
## Summary
- speed up sponsor carousel and apply it on main and About pages
- show new event photos in Events page slider
- update About page history slider images
- use correct mission image
- adjust DatathonX winner photos to show faces

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686add0f466483318f0769badfa2424c