### PR TITLE
Add full event galleries and shared project cards

### DIFF
--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -1,0 +1,34 @@
+import { FaGithub, FaLinkedin } from 'react-icons/fa'
+
+export default function ProjectCard({ name, link, desc, ownerName, ownerLinkedIn }) {
+  return (
+    <div className="border rounded-lg p-6 shadow hover:shadow-lg transition flex flex-col justify-between bg-white">
+      <div>
+        <h3 className="text-xl font-semibold mb-2">{name}</h3>
+        <p className="text-sm mb-6">{desc}</p>
+      </div>
+      <div className="flex items-center justify-between text-sm mt-auto">
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-dsccGreen hover:text-dsccOrange flex items-center gap-1"
+        >
+          <FaGithub />
+          <span>GitHub</span>
+        </a>
+        {ownerLinkedIn && ownerName && (
+          <a
+            href={ownerLinkedIn}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-dsccGreen hover:text-dsccOrange flex items-center gap-1"
+          >
+            <FaLinkedin />
+            <span>{ownerName}</span>
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/data/projects.js
+++ b/data/projects.js
@@ -1,0 +1,23 @@
+export const projects = [
+  {
+    name: 'SmartNews360',
+    link: 'https://github.com/example/smartnews360',
+    desc: 'Agrégation intelligente d\u2019actualités.',
+    ownerName: 'A. El Idrissi',
+    ownerLinkedIn: 'https://www.linkedin.com/in/a-el-idrissi'
+  },
+  {
+    name: 'DataViz ENSA',
+    link: 'https://github.com/example/dataviz',
+    desc: 'Tableau de bord interactif.',
+    ownerName: 'B. Khadija',
+    ownerLinkedIn: 'https://www.linkedin.com/in/b-khadija'
+  },
+  {
+    name: 'IA & Santé',
+    link: 'https://github.com/example/healthai',
+    desc: 'Exploration de données médicales.',
+    ownerName: 'C. Yassine',
+    ownerLinkedIn: 'https://www.linkedin.com/in/c-yassine'
+  }
+]

--- a/pages/about.js
+++ b/pages/about.js
@@ -134,14 +134,22 @@ export default function Page() {
             images={[
               '/event/Screenshot 2025-07-06 212003.png',
               '/event/Screenshot 2025-07-06 212023.png',
-              '/event/Screenshot 2025-07-06 212041.png'
+              '/event/Screenshot 2025-07-06 212041.png',
+              '/event/Screenshot 2025-07-06 212101.png',
+              '/event/Screenshot 2025-07-06 212116.png',
+              '/event/Screenshot 2025-07-06 212130.png',
+              '/event/Screenshot 2025-07-06 212147.png'
             ]}
           />
           <ImageSlider
             images={[
-              '/event/Screenshot 2025-07-06 212101.png',
-              '/event/Screenshot 2025-07-06 212116.png',
-              '/event/Screenshot 2025-07-06 212130.png'
+              '/event/Screenshot 2025-07-06 212211.png',
+              '/event/Screenshot 2025-07-06 212230.png',
+              '/event/Screenshot 2025-07-06 212254.png',
+              '/event/Screenshot 2025-07-06 212342.png',
+              '/event/Screenshot 2025-07-06 212407.png',
+              '/event/Screenshot 2025-07-06 212420.png',
+              '/event/Screenshot 2025-07-06 212446.png'
             ]}
           />
           <Timeline />

--- a/pages/events.js
+++ b/pages/events.js
@@ -29,12 +29,20 @@ export default function Page() {
   const images1 = [
     '/event/Screenshot 2025-07-06 212003.png',
     '/event/Screenshot 2025-07-06 212023.png',
-    '/event/Screenshot 2025-07-06 212041.png'
-  ]
-  const images2 = [
+    '/event/Screenshot 2025-07-06 212041.png',
     '/event/Screenshot 2025-07-06 212101.png',
     '/event/Screenshot 2025-07-06 212116.png',
-    '/event/Screenshot 2025-07-06 212130.png'
+    '/event/Screenshot 2025-07-06 212130.png',
+    '/event/Screenshot 2025-07-06 212147.png'
+  ]
+  const images2 = [
+    '/event/Screenshot 2025-07-06 212211.png',
+    '/event/Screenshot 2025-07-06 212230.png',
+    '/event/Screenshot 2025-07-06 212254.png',
+    '/event/Screenshot 2025-07-06 212342.png',
+    '/event/Screenshot 2025-07-06 212407.png',
+    '/event/Screenshot 2025-07-06 212420.png',
+    '/event/Screenshot 2025-07-06 212446.png'
   ]
   return (
     <Layout title="Événements">

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,6 +20,8 @@ import {
   FaArrowRight
 } from 'react-icons/fa';
 import AnimatedSection from '../components/AnimatedSection'
+import ProjectCard from '../components/ProjectCard'
+import { projects } from '../data/projects'
 
 export default function Home() {
   // Slides displayed in the hero section
@@ -153,9 +155,9 @@ export default function Home() {
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Projets du Club</h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-            <ProjectCard icon="/icons/reco.png" title="Système de Recommandation" />
-            <ProjectCard icon="/icons/nlp.png" title="Analyse des Sentiments" />
-            <ProjectCard icon="/icons/forecast.png" title="Prédiction de Ventes" />
+            {projects.slice(0, 3).map((p, idx) => (
+              <ProjectCard key={idx} {...p} />
+            ))}
           </div>
           <div className="text-center mt-10">
             <Link href="/projects" className="text-dsccGreen underline hover:text-dsccOrange inline-flex items-center gap-1">
@@ -255,21 +257,6 @@ function EventCard({ img, title, tag }){
   )
 }
 
-function ProjectCard({ icon, title }){
-  return (
-    <motion.div
-      className="bg-lightGray rounded-xl p-6 text-center shadow"
-      whileHover={{ scale: 1.05 }}
-      initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ type: 'spring', stiffness: 300 }}
-    >
-      <Image src={icon} alt={title} width={64} height={64} className="mx-auto mb-4" />
-      <h4 className="font-semibold">{title}</h4>
-    </motion.div>
-  )
-}
 
 function TeamCard({ img, name, role }){
   return (

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -1,7 +1,9 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
 import Link from 'next/link'
-import { FaArrowRight, FaGithub, FaLinkedin } from 'react-icons/fa'
+import { FaArrowRight } from 'react-icons/fa'
+import ProjectCard from '../components/ProjectCard'
+import { projects } from '../data/projects'
 import { useState, useEffect } from 'react'
 
 export default function Page(){
@@ -54,59 +56,3 @@ export default function Page(){
   )
 }
 
-function ProjectCard({ name, link, desc, ownerName, ownerLinkedIn }) {
-  return (
-    <div className="border rounded-lg p-6 shadow hover:shadow-lg transition flex flex-col justify-between bg-white">
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{name}</h3>
-        <p className="text-sm mb-6">{desc}</p>
-      </div>
-      <div className="flex items-center justify-between text-sm mt-auto">
-        <a
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-dsccGreen hover:text-dsccOrange flex items-center gap-1"
-        >
-          <FaGithub />
-          <span>GitHub</span>
-        </a>
-        {ownerLinkedIn && ownerName && (
-          <a
-            href={ownerLinkedIn}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-dsccGreen hover:text-dsccOrange flex items-center gap-1"
-          >
-            <FaLinkedin />
-            <span>{ownerName}</span>
-          </a>
-        )}
-      </div>
-    </div>
-  )
-}
-
-const projects = [
-  {
-    name: 'SmartNews360',
-    link: 'https://github.com/example/smartnews360',
-    desc: 'Agrégation intelligente d’actualités.',
-    ownerName: 'A. El Idrissi',
-    ownerLinkedIn: 'https://www.linkedin.com/in/a-el-idrissi'
-  },
-  {
-    name: 'DataViz ENSA',
-    link: 'https://github.com/example/dataviz',
-    desc: 'Tableau de bord interactif.',
-    ownerName: 'B. Khadija',
-    ownerLinkedIn: 'https://www.linkedin.com/in/b-khadija'
-  },
-  {
-    name: 'IA & Santé',
-    link: 'https://github.com/example/healthai',
-    desc: 'Exploration de données médicales.',
-    ownerName: 'C. Yassine',
-    ownerLinkedIn: 'https://www.linkedin.com/in/c-yassine'
-  }
-]


### PR DESCRIPTION
## Summary
- create reusable `ProjectCard` component
- move project data to `data/projects.js`
- use real project cards on homepage and projects page
- include all event images in about and events sliders

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ae4afbad483318d5584dd6ee8802c