### PR TITLE
Fix Firebase add/delete in admin dashboard

### DIFF
--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -1,19 +1,17 @@
 import { initializeApp } from 'firebase/app'
-import { getAnalytics } from 'firebase/analytics'
 import { getFirestore } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: 'AIzaSyAv23pEzyKyqWnLFc9twwClFf7iY9mMA0M',
   authDomain: 'clubdscc.firebaseapp.com',
   projectId: 'clubdscc',
-  storageBucket: 'clubdscc.firebasestorage.app',
+  storageBucket: 'clubdscc.appspot.com',
   messagingSenderId: '355759537454',
   appId: '1:355759537454:web:4118ecfa742e9078f14ebf',
   measurementId: 'G-CS3BMKJ1JG'
 }
 
 const app = initializeApp(firebaseConfig)
-const analytics = typeof window !== 'undefined' ? getAnalytics(app) : null
 const db = getFirestore(app)
 
-export { app, analytics, db }
+export { app, db }

--- a/pages/admin1/dashboard.js
+++ b/pages/admin1/dashboard.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import Layout from '../../components/Layout'
 import { db } from '../../lib/firebase'
-import { collection, addDoc } from 'firebase/firestore'
 
 export default function Dashboard() {
   const router = useRouter()
@@ -55,6 +54,7 @@ export default function Dashboard() {
     e.preventDefault()
     const newProj = { name, link, desc, ownerLinkedIn: projectLinkedIn }
     try {
+      const { collection, addDoc } = await import('firebase/firestore')
       const docRef = await addDoc(collection(db, 'projects'), newProj)
       newProj.id = docRef.id
     } catch (err) {


### PR DESCRIPTION
## Summary
- dynamically import Firestore methods when adding a project
- remove unused analytics code and correct storage bucket config

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c047360d883318da98519b9c15bc2