### PR TITLE
Add Firebase dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Ce projet contient un squelette complet pour le site officiel du **Data Science 
 - Pages prêtes à l’emploi : Home, À propos, Événements, Projets, DatathonX, Équipe, Ressources, Contact
 - Layout, Header, Footer déjà stylés
 - Script `npm run dev` pour lancer le serveur local
+- Intégration optionnelle de **Firebase** pour stocker projets et messages
 
 ## Installation rapide
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.12.0",
-    "framer-motion": "^10.16.1"
+    "framer-motion": "^10.16.1",
+    "firebase": "^9.23.0"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",


### PR DESCRIPTION
## Summary
- add `firebase` dependency for Firestore integration
- document optional Firebase usage in README

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c06a067508331b940ce264bbcf920