### PR TITLE
Improve event card and team image handling

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -39,7 +39,8 @@ export default function Home() {
       img: '/cards/introduction%20%C3%A0%20python.png',
       title: 'Introduction à Python',
       tag: 'Session',
-      desc: "Une initiation pratique au langage Python pour bien débuter."
+      desc: "Une initiation pratique au langage Python pour bien débuter.",
+      link: '/python-lessons'
     },
     {
       img: '/cards/mentorship%20fridays.png',
@@ -274,8 +275,8 @@ function Objective({ icon: Icon, title }){
   )
 }
 
-function EventCard({ img, title, tag, desc }){
-  return (
+function EventCard({ img, title, tag, desc, link }){
+  const content = (
     <div
       className="masonry-item bg-white rounded-lg shadow hover:shadow-lg overflow-hidden hover:duration-300"
       whileHover={{ scale: 1.03 }}
@@ -284,7 +285,7 @@ function EventCard({ img, title, tag, desc }){
       viewport={{ once: true }}
       transition={{ type: 'spring', stiffness: 300 }}
     >
-      <Image src={img} alt={title} width={400} height={250} className="w-full h-48 object-contain" />
+      <Image src={img} alt={title} width={400} height={250} className="w-full h-48 object-cover" />
       <div className="p-4 space-y-1">
         <span className="text-xs uppercase tracking-wider text-dsccOrange">{tag}</span>
         <h4 className="text-lg font-semibold">{title}</h4>
@@ -292,6 +293,7 @@ function EventCard({ img, title, tag, desc }){
       </div>
     </div>
   )
+  return link ? <Link href={link}>{content}</Link> : content
 }
 
 

--- a/pages/team.js
+++ b/pages/team.js
@@ -35,10 +35,10 @@ export default function Page() {
         <div className="container mx-auto px-4 max-w-5xl">
           <h2 className="text-3xl font-bold mb-8 text-center">Équipe Pilotage</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-            {pilotageTeam.map((m, idx) => (
+            {pilotageTeam.map(m => (
               <div key={m.name} className="text-center">
                 <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
-                  <img src={`/team/${idx + 1}.jpg`} alt={m.name} className="object-cover w-full h-full" />
+                  <img src={`/team/${m.img}`} alt={m.name} className="object-cover w-full h-full" />
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white p-2 text-sm transition text-center">
                     {quotesByRole[m.role]}
                   </div>
@@ -56,10 +56,10 @@ export default function Page() {
         <div className="container mx-auto px-4 max-w-5xl">
           <h2 className="text-3xl font-bold mb-8 text-center">Équipe Responsables</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-            {responsableTeam.map((m, idx) => (
+            {responsableTeam.map(m => (
               <div key={m.name} className="text-center">
                 <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
-                  <img src={`/team/${pilotageTeam.length + idx + 1}.jpg`} alt={m.name} className="object-cover w-full h-full" />
+                  <img src={`/team/${m.img}`} alt={m.name} className="object-cover w-full h-full" />
                   <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white p-2 text-sm transition text-center">
                     {quotesByRole[m.role]}
                   </div>
@@ -118,22 +118,22 @@ const quotesByRole = {
 }
 
 const pilotageTeam = [
-  { name: 'Jawad Elkharrati', role: 'Président' },
-  { name: 'Aya El Farssia', role: 'Vice-Présidente' },
-  { name: 'Hanae Cherif', role: 'Secrétaire' },
-  { name: 'Oumaima Sahli', role: 'Trésorière' },
-  { name: 'Iyad Beddidi', role: 'Responsable RH' },
+  { name: 'Jawad Elkharrati', role: 'Président', img: 'jawad.JPG' },
+  { name: 'Aya El Farssia', role: 'Vice-Présidente', img: 'aya.jpeg' },
+  { name: 'Hanae Cherif', role: 'Secrétaire', img: 'hanae.jpg' },
+  { name: 'Oumaima Sahli', role: 'Trésorière', img: 'oumaima.jpeg' },
+  { name: 'Iyad Beddidi', role: 'Responsable RH', img: 'iyad.jpeg' },
 ]
 
 const responsableTeam = [
-  { name: 'El Wazani Mohamed', role: 'Responsable Design' },
-  { name: 'Houciene Benhaddou', role: 'Responsable Maison de Science' },
-  { name: 'Safae Azizi', role: 'Responsable Média' },
-  { name: 'Jinane Ait Elabd', role: 'Responsable Montage' },
-  { name: 'Mostafa Alaoui', role: 'Responsable Logistique' },
-  { name: 'Amine Chakri', role: 'Responsable Compétition' },
-  { name: 'EL MOUSSAOUI Oussama', role: 'Responsable Journée' },
-  { name: 'Badreddine Chihab', role: 'Responsable Sponsoring' },
-  { name: 'Wafae Zalouk', role: 'Responsable Rédaction' },
-  { name: 'Zakaria Taibi', role: 'Responsable Formation' },
+  { name: 'El Wazani Mohamed', role: 'Responsable Design', img: 'jawad.JPG' },
+  { name: 'Houciene Benhaddou', role: 'Responsable Maison de Science', img: 'houcein.jpg' },
+  { name: 'Safae Azizi', role: 'Responsable Média', img: 'safae.jpeg' },
+  { name: 'Jinane Ait Elabd', role: 'Responsable Montage', img: 'jinane.png' },
+  { name: 'Mostafa Alaoui', role: 'Responsable Logistique', img: 'mustafa.jpg' },
+  { name: 'Amine Chakri', role: 'Responsable Compétition', img: 'amine.jpg' },
+  { name: 'EL MOUSSAOUI Oussama', role: 'Responsable Journée', img: 'oussama.jpg' },
+  { name: 'Badreddine Chihab', role: 'Responsable Sponsoring', img: 'badr.jpeg' },
+  { name: 'Wafae Zalouk', role: 'Responsable Rédaction', img: 'wafae.jpg' },
+  { name: 'Zakaria Taibi', role: 'Responsable Formation', img: 'zakaria.jpg' },
 ]


### PR DESCRIPTION
## Summary
- link home page Python card to lesson page
- display event card images with `object-cover` and optional link
- map team member photos by name instead of placeholder numbers

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c50d3f248331a5629915ae26b802