### PR TITLE
Update Python lessons guide with code cards

### DIFF
--- a/components/CodeCard.js
+++ b/components/CodeCard.js
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import { FaCopy } from 'react-icons/fa'
+
+export default function CodeCard({ children }) {
+  const [copied, setCopied] = useState(false)
+  const handleCopy = () => {
+    navigator.clipboard.writeText(children)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="relative bg-lightGray dark:bg-darkText/20 rounded-md p-4 font-mono text-sm overflow-auto">
+      <pre>{children}</pre>
+      <button
+        onClick={handleCopy}
+        className="absolute top-2 right-2 text-gray-500 hover:text-dsccOrange"
+        aria-label="Copier le code"
+      >
+        {copied ? 'Copié !' : <FaCopy />}
+      </button>
+    </div>
+  )
+}

--- a/pages/python-lessons.js
+++ b/pages/python-lessons.js
@@ -1,5 +1,6 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
+import CodeCard from '../components/CodeCard'
 
 export default function PythonLessons() {
   return (
@@ -9,8 +10,8 @@ export default function PythonLessons() {
         <div className="absolute inset-0 bg-cover bg-center opacity-80" style={{ backgroundImage: 'url(/2.jpg)' }} />
         <div className="absolute inset-0 bg-gradient-to-r from-dsccGreen/70 to-dsccOrange/70" />
         <div className="relative z-10 text-center px-4">
-          <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Ultimate Python Guide 2025</h1>
-          <p className="max-w-2xl mx-auto text-lg md:text-xl">All the essentials for data scientists using Python.</p>
+          <h1 className="text-4xl md:text-6xl font-extrabold mb-4">Guide Ultime de Python 2025</h1>
+          <p className="max-w-2xl mx-auto text-lg md:text-xl">Toutes les bases pour exceller en data science.</p>
         </div>
       </section>
 
@@ -18,86 +19,181 @@ export default function PythonLessons() {
       <AnimatedSection className="py-20 bg-white" direction="up">
         <div className="container mx-auto px-4 space-y-12 max-w-3xl">
           <section>
-            <h2 className="text-2xl font-bold mb-2">Introduction</h2>
-            <p>Whether you're entering data science or sharpening skills, this guide covers tools from data wrangling to machine learning.</p>
+            <h2 className="text-2xl font-bold mb-2">📌 Introduction</h2>
+            <p>Python est l'outil indispensable des data scientists. Sa puissance et sa simplicité permettent d'analyser des données, de construire des modèles de machine learning ou encore de développer des API en un temps record.</p>
           </section>
+
           <section>
-            <h2 className="text-2xl font-bold mb-2">Why Python for Data Science?</h2>
+            <h2 className="text-2xl font-bold mb-2">🔍 Pourquoi Python ?</h2>
             <ul className="list-disc pl-6 space-y-1">
-              <li>Readable and intuitive with a vast community.</li>
-              <li>Rich ecosystem for manipulation, analysis and visualization.</li>
-              <li>Widely used in production and ML pipelines.</li>
+              <li>Syntaxe claire et lisible</li>
+              <li>Énorme écosystème de bibliothèques</li>
+              <li>Support communautaire open source</li>
+              <li>Intégration facile avec bases de données et outils cloud</li>
             </ul>
           </section>
-          <section>
-            <h2 className="text-2xl font-bold mb-2">Essential Libraries</h2>
-            <ul className="list-disc pl-6 space-y-1">
-              <li><strong>NumPy</strong> – numerical computing foundation.</li>
-              <li><strong>Pandas</strong> – data manipulation with DataFrames.</li>
-              <li><strong>Matplotlib &amp; Seaborn</strong> – visualization tools.</li>
-              <li><strong>Scikit-learn</strong> – classical machine learning.</li>
-              <li><strong>SciPy</strong> – scientific computing.</li>
-              <li><strong>Statsmodels</strong> – statistical modeling.</li>
-              <li><strong>XGBoost / LightGBM / CatBoost</strong> – gradient boosting.</li>
-              <li><strong>TensorFlow / PyTorch</strong> – deep learning frameworks.</li>
-            </ul>
+
+          <section className="space-y-6">
+            <h2 className="text-2xl font-bold mb-2">🧰 Bibliothèques essentielles</h2>
+            <div className="border-l-4 border-dsccOrange bg-lightGray p-4 rounded space-y-4">
+              <div>
+                <h3 className="font-semibold">1. NumPy – Calcul numérique</h3>
+                <CodeCard>{`import numpy as np
+
+a = np.array([1, 2, 3])
+b = np.array([4, 5, 6])
+produit = np.dot(a, b)`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">2. Pandas – Manipulation de données</h3>
+                <CodeCard>{`import pandas as pd
+
+df = pd.read_csv("data.csv")
+df.info()
+df["revenu_moyen"] = df["revenu"].mean()`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">3. Matplotlib & Seaborn – Visualisation</h3>
+                <CodeCard>{`import matplotlib.pyplot as plt
+import seaborn as sns
+
+sns.histplot(df["âge"], kde=True)
+plt.title("Distribution des âges")
+plt.show()`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">4. Scikit-learn – Machine Learning</h3>
+                <CodeCard>{`from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import classification_report
+
+X = df[["âge", "revenu"]]
+y = df["achat"]
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)
+
+model = RandomForestClassifier()
+model.fit(X_train, y_train)
+y_pred = model.predict(X_test)
+
+print(classification_report(y_test, y_pred))`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">5. Statsmodels – Analyse statistique</h3>
+                <CodeCard>{`import statsmodels.api as sm
+
+X = sm.add_constant(df["revenu"])
+model = sm.OLS(df["score"], X).fit()
+print(model.summary())`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">6. XGBoost / LightGBM / CatBoost – Boosting avancé</h3>
+                <CodeCard>{`import xgboost as xgb
+
+dtrain = xgb.DMatrix(X_train, label=y_train)
+params = {"objective": "binary:logistic"}
+bst = xgb.train(params, dtrain, num_boost_round=10)`}</CodeCard>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-6">
+            <h2 className="text-2xl font-bold mb-2">🔄 Workflow type</h2>
+            <div className="space-y-6">
+              <div>
+                <h3 className="font-semibold">1. Collecte de données</h3>
+                <CodeCard>{`import requests
+
+url = "https://api.exemple.com/data"
+reponse = requests.get(url)
+donnees = reponse.json()`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">2. Nettoyage & Prétraitement</h3>
+                <CodeCard>{`df.dropna(inplace=True)
+df["âge"] = df["âge"].astype(int)`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">3. Exploration des données (EDA)</h3>
+                <CodeCard>{`df.describe()
+df["catégorie"].value_counts()
+sns.pairplot(df, hue="cible")`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">4. Feature Engineering</h3>
+                <CodeCard>{`from sklearn.preprocessing import StandardScaler
+
+scaler = StandardScaler()
+df[["revenu", "âge"]] = scaler.fit_transform(df[["revenu", "âge"]])`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">5. Modélisation & Évaluation</h3>
+                <CodeCard>{`from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import confusion_matrix
+
+model = LogisticRegression()
+model.fit(X_train, y_train)
+y_pred = model.predict(X_test)
+
+print(confusion_matrix(y_test, y_pred))`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">6. Interprétation des résultats</h3>
+                <CodeCard>{`import shap
+
+explainer = shap.Explainer(model, X_train)
+shap_values = explainer(X_test)
+shap.plots.beeswarm(shap_values)`}</CodeCard>
+              </div>
+              <div>
+                <h3 className="font-semibold">7. Déploiement (optionnel)</h3>
+                <CodeCard>{`from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route("/predict", methods=["POST"])
+def predict():
+    data = request.get_json()
+    prediction = model.predict([data["features"]])
+    return jsonify(prediction=prediction.tolist())`}</CodeCard>
+              </div>
+            </div>
           </section>
           <section>
-            <h2 className="text-2xl font-bold mb-2">Data Workflow</h2>
-            <ol className="list-decimal pl-6 space-y-1">
-              <li>Data collection with requests, BeautifulSoup, APIs.</li>
-              <li>Cleaning: handle missing values and encode features.</li>
-              <li>EDA with summaries and visualizations.</li>
-              <li>Feature engineering and scaling.</li>
-              <li>Model building and evaluation.</li>
-              <li>Optional deployment with Flask, FastAPI or Streamlit.</li>
-            </ol>
-          </section>
-          <section>
-            <h2 className="text-2xl font-bold mb-2">Advanced Tools</h2>
-            <ul className="list-disc pl-6 space-y-1">
-              <li>Jupyter Notebooks for prototyping.</li>
-              <li>Airflow or Prefect for orchestration.</li>
-              <li>Dask or Vaex for big data.</li>
-              <li>Hugging Face Transformers for NLP.</li>
-              <li>LangChain or LlamaIndex for LLM apps.</li>
-              <li>MLflow for experiment tracking.</li>
-            </ul>
-          </section>
-          <section>
-            <h2 className="text-2xl font-bold mb-2">Learning Path</h2>
-            <ul className="list-disc pl-6 space-y-1">
-              <li>Start with Python fundamentals.</li>
-              <li>Explore NumPy, Pandas and Matplotlib.</li>
-              <li>Clean data and practice EDA.</li>
-              <li>Build ML models with scikit-learn.</li>
-              <li>Dive into deep learning with PyTorch or TensorFlow.</li>
-              <li>Work on a capstone project and use Git and Docker.</li>
-            </ul>
-          </section>
-          <section>
-            <h2 className="text-2xl font-bold mb-2">Sample Project Structure</h2>
-            <pre className="bg-lightGray p-4 rounded"><code>{`my_project/
+            <h2 className="text-2xl font-bold mb-2">📁 Structure conseillée</h2>
+            <pre className="bg-lightGray p-4 rounded"><code>mon_projet/
 ├── data/
 ├── notebooks/
 ├── scripts/
 ├── models/
+├── app/
 ├── requirements.txt
-└── README.md`}</code></pre>
+└── README.md</code></pre>
           </section>
+
           <section>
-            <h2 className="text-2xl font-bold mb-2">Resources</h2>
+            <h2 className="text-2xl font-bold mb-2">🎓 Ressources recommandées</h2>
             <ul className="list-disc pl-6 space-y-1">
-              <li>Kaggle</li>
-              <li>Scikit-learn Documentation</li>
-              <li>Fast.ai</li>
-              <li>Hugging Face</li>
-              <li>Python Data Science Handbook</li>
+              <li>"Python pour l'analyse de données" – Wes McKinney</li>
+              <li>Kaggle : compétitions et datasets</li>
+              <li>OpenClassrooms : formations en ligne</li>
+              <li>Documentation Scikit-learn</li>
+              <li>Fast.ai – cours gratuits en deep learning</li>
             </ul>
           </section>
+
           <section>
-            <h2 className="text-2xl font-bold mb-2">Final Thoughts</h2>
-            <p>Python remains essential for data science—mastering its ecosystem opens doors to impactful projects.</p>
+            <h2 className="text-2xl font-bold mb-2">✅ Conseils pratiques</h2>
+            <ul className="list-disc pl-6 space-y-1">
+              <li>Ne négligez jamais l'étape de nettoyage des données.</li>
+              <li>Commencez simple avant de passer à des modèles complexes.</li>
+              <li>Documentez chaque étape de vos notebooks et scripts.</li>
+              <li>Automatisez vos pipelines avec Airflow ou Prefect.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-2xl font-bold mb-2">🚀 Conclusion</h2>
+            <p>Maîtriser Python en data science va au-delà du simple code&nbsp;: c'est comprendre la donnée, modéliser intelligemment et livrer des solutions à impact. Ce guide vous donne les clés pour réussir vos projets en 2025 et au-delà.</p>
           </section>
         </div>
       </AnimatedSection>


### PR DESCRIPTION
## Summary
- add new CodeCard component for styled code blocks
- rewrite `python-lessons` page with expanded guide content

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ca9be6208331b68dbd7f3c5cf1be