### PR TITLE
Fix mobile layout overflow

### DIFF
--- a/components/CodeCard.js
+++ b/components/CodeCard.js
@@ -10,8 +10,8 @@ export default function CodeCard({ children }) {
   }
 
   return (
-    <div className="relative bg-lightGray dark:bg-darkText/20 rounded-md p-4 font-mono text-sm overflow-auto">
-      <pre>{children}</pre>
+    <div className="relative bg-lightGray dark:bg-darkText/20 rounded-md p-4 font-mono text-sm overflow-x-auto">
+      <pre className="whitespace-pre">{children}</pre>
       <button
         onClick={handleCopy}
         className="absolute top-2 right-2 text-gray-500 hover:text-dsccOrange"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,6 +10,7 @@
 }
 html {
   scroll-behavior: smooth;
+  overflow-x-hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary
- hide horizontal overflow globally
- ensure code blocks only scroll sideways

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878d00635f88331934a455c9dac7d02