### PR TITLE
Fix PostCSS configuration for Tailwind

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,7 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: [
+    require('tailwindcss'),
+    require('autoprefixer')
+  ]
 }
+


### PR DESCRIPTION
## Summary
- update postcss.config.js to use require syntax for Tailwind and Autoprefixer

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d18ab32483319cbe1110d1de71d3