### PR TITLE
Fix PostCSS plugin syntax for Next.js 14

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
-  plugins: [
-    require('tailwindcss'),
-    require('autoprefixer')
-  ]
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }
 


### PR DESCRIPTION
## Summary
- update PostCSS configuration to use plugin names instead of `require()`

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6878d2f7c0a0833184627cbff0dac5f9