### PR TITLE
Fix CSS overflow syntax

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -10,7 +10,7 @@
 }
 html {
   scroll-behavior: smooth;
-  overflow-x-hidden;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
## Summary
- fix `overflow-x` property syntax in `styles/globals.css`

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d6937e44833191d347e22924260e