### PR TITLE
Add laureate slider section

### DIFF
--- a/components/CardSlider.js
+++ b/components/CardSlider.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+export default function CardSlider({ children }) {
+  const slides = React.Children.toArray(children)
+  const duplicated = [...slides, ...slides]
+  return (
+    <div className="overflow-hidden w-full my-6">
+      <div className="flex gap-6 slide-left w-max">
+        {duplicated.map((child, i) => (
+          <div key={i} className="flex-shrink-0">{child}</div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/LaureatCard.js
+++ b/components/LaureatCard.js
@@ -1,0 +1,23 @@
+import { FaLinkedin } from 'react-icons/fa'
+
+export default function LaureatCard({ img, name, role, linkedin }) {
+  return (
+    <div className="text-center flex flex-col items-center">
+      <div className="h-32 w-32 rounded-full overflow-hidden mb-2 bg-gray-200">
+        <img src={img} alt={name} className="object-cover w-full h-full" />
+      </div>
+      <p className="font-semibold">{name}</p>
+      {role && <p className="text-sm text-gray-500">{role}</p>}
+      {linkedin && (
+        <a
+          href={linkedin}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-dsccGreen hover:text-dsccOrange text-2xl mt-2"
+        >
+          <FaLinkedin />
+        </a>
+      )}
+    </div>
+  )
+}

--- a/data/laureats.json
+++ b/data/laureats.json
@@ -1,1 +1,20 @@
-[]
+[
+  {
+    "name": "Aissam Bakhtaoui",
+    "role": "Data Scientist at Tessi",
+    "linkedin": "https://www.linkedin.com/in/aissam-bakhtaoui",
+    "img": "/laureat/aissam.jfif"
+  },
+  {
+    "name": "M’hamed Issam ED-DAOU",
+    "role": "Engineer & Consultant — Data @VISEO",
+    "linkedin": "https://www.linkedin.com/in/issam-eddaou",
+    "img": "/laureat/issam.jfif"
+  },
+  {
+    "name": "Mohammed Herrag",
+    "role": "Data Analyst",
+    "linkedin": "https://www.linkedin.com/in/mohammed-herrag",
+    "img": "/laureat/mohammed.jfif"
+  }
+]

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -1,8 +1,10 @@
 import Layout from '../components/Layout'
 import AnimatedSection from '../components/AnimatedSection'
 import Link from 'next/link'
-import { FaArrowRight, FaLinkedin } from 'react-icons/fa'
+import { FaArrowRight } from 'react-icons/fa'
 import { useState, useEffect } from 'react'
+import LaureatCard from '../components/LaureatCard'
+import CardSlider from '../components/CardSlider'
 
 export default function Page() {
   const [drives, setDrives] = useState([])
@@ -81,11 +83,11 @@ export default function Page() {
       <AnimatedSection id="laureats" className="py-20 bg-white" direction="left">
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Nos lauréats</h2>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+          <CardSlider>
             {laureats.map((l, i) => (
               <LaureatCard key={i} {...l} />
             ))}
-          </div>
+          </CardSlider>
         </div>
       </AnimatedSection>
 
@@ -102,18 +104,3 @@ export default function Page() {
   )
   }
 
-function LaureatCard({ name, linkedin }) {
-  return (
-    <div className="border rounded-lg p-6 shadow hover:shadow-lg transition flex flex-col items-center bg-white text-center">
-      <p className="font-semibold mb-4">{name}</p>
-      <a
-        href={linkedin}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-dsccGreen hover:text-dsccOrange text-3xl mt-auto"
-      >
-        <FaLinkedin />
-      </a>
-    </div>
-  )
-}


### PR DESCRIPTION
## Summary
- add `LaureatCard` for displaying a laureate with image and link
- add generic `CardSlider` to continuously slide cards
- list laureates in `data/laureats.json`
- show laureates in a sliding carousel on the resources page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878d93e772c8331a126a97436d204a9