### PR TITLE
Add laureates and split slider

### DIFF
--- a/data/laureats.json
+++ b/data/laureats.json
@@ -60,4 +60,35 @@
     "linkedin": "https://www.linkedin.com/in/hanae-lahbouchi-51103419a/",
     "img": "/laureat/test"
   }
+  ,
+  {
+    "name": "Kamal Lazhar",
+    "role": "Data Engineer at Stellantis",
+    "linkedin": "https://www.linkedin.com/in/kamal-lazhar-2414291a6/",
+    "img": "/laureat/test"
+  },
+  {
+    "name": "Jouhayna Achargui",
+    "role": "Cloud Engineer @Capgemini | DevOps | Azure Certified | GCP Certified",
+    "linkedin": "https://www.linkedin.com/in/jouhayna-achargui-b18687202/",
+    "img": "/laureat/test"
+  },
+  {
+    "name": "Hanifa Elaissaoui",
+    "role": "Ingénieur d'état en Data Science et Cloud Computing",
+    "linkedin": "https://www.linkedin.com/in/hanifa-elaissaoui-b443b7193/",
+    "img": "/laureat/test"
+  },
+  {
+    "name": "Anouar ASSAKALI",
+    "role": "Ingénieur Data Scientist | Ministère de l'Économie et des Finances | Direction Générale des Impôts.",
+    "linkedin": "https://www.linkedin.com/in/assakali-anouar/",
+    "img": "/laureat/test"
+  },
+  {
+    "name": "Amine Saihi",
+    "role": "AI/ML & NLP at Archipel Cognitive",
+    "linkedin": "https://www.linkedin.com/in/amine-saihi/",
+    "img": "/laureat/test"
+  }
 ]

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -9,6 +9,9 @@ import CardSlider from '../components/CardSlider'
 export default function Page() {
   const [drives, setDrives] = useState([])
   const [laureats, setLaureats] = useState([])
+  const mid = Math.ceil(laureats.length / 2)
+  const firstHalf = laureats.slice(0, mid)
+  const secondHalf = laureats.slice(mid)
 
   useEffect(() => {
     fetch('/api/drives')
@@ -84,7 +87,12 @@ export default function Page() {
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Nos lauréats</h2>
           <CardSlider>
-            {laureats.map((l, i) => (
+            {firstHalf.map((l, i) => (
+              <LaureatCard key={i} {...l} />
+            ))}
+          </CardSlider>
+          <CardSlider>
+            {secondHalf.map((l, i) => (
               <LaureatCard key={i} {...l} />
             ))}
           </CardSlider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -23,7 +23,7 @@ body {
 }
 
   .slide-right {
-    animation: slideRight 40s linear infinite;
+    animation: slideRight 30s linear infinite;
   }
 
 @keyframes slideLeft {
@@ -32,12 +32,12 @@ body {
 }
 
   .slide-left {
-    animation: slideLeft 40s linear infinite;
+    animation: slideLeft 30s linear infinite;
   }
 
   /* Faster scrolling for sponsor logos */
   .sponsor-scroll {
-    animation: slideLeft 40s linear infinite;
+    animation: slideLeft 30s linear infinite;
   }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- add new laureates in `data/laureats.json`
- split laureate carousel into two sliders
- speed up slide animation slightly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e4519da883318fc14c43a40fdb3b