### PR TITLE
Add LinkedIn links for team profiles

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -206,10 +206,30 @@ export default function Home() {
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Équipe actuelle</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 xl:grid-cols-5 gap-8 justify-items-center max-w-5xl mx-auto">
-            <TeamCard img="/team/jawad.JPG" name="Jawad Elkharrati" role="Président" />
-            <TeamCard img="/team/aya.jpeg" name="Aya El Farssia" role="Vice‑présidente" />
-            <TeamCard img="/team/hanae.jpg" name="Hanae Cherif" role="Secrétaire" />
-            <TeamCard img="/team/oumaima.jpeg" name="Oumaima Sahli" role="Trésorière" />
+            <TeamCard
+              img="/team/jawad.JPG"
+              name="Jawad Elkharrati"
+              role="Président"
+              link="https://www.linkedin.com/in/jawad-elkharrati/"
+            />
+            <TeamCard
+              img="/team/aya.jpeg"
+              name="Aya El Farssia"
+              role="Vice‑présidente"
+              link="https://ma.linkedin.com/in/aya-el-fassi-3a451b1b9"
+            />
+            <TeamCard
+              img="/team/hanae.jpg"
+              name="Hanae Cherif"
+              role="Secrétaire"
+              link="https://ma.linkedin.com/in/hanae-cherif-31b218344"
+            />
+            <TeamCard
+              img="/team/oumaima.jpeg"
+              name="Oumaima Sahli"
+              role="Trésorière"
+              link="https://ma.linkedin.com/in/sahli-oumaima-b8ab8831b"
+            />
             <TeamCard img="/team/iyad.jpeg" name="Iyad Beddidi" role="Résponsable RH" />
           </div>
           <div className="text-center mt-10">
@@ -275,8 +295,8 @@ function Objective({ icon: Icon, title }){
 
 
 
-function TeamCard({ img, name, role }){
-  return (
+function TeamCard({ img, name, role, link }) {
+  const Card = (
     <motion.div
       className="bg-white dark:bg-darkText text-center shadow-lg rounded-2xl p-6 transition-shadow hover:shadow-xl"
       whileHover={{ scale: 1.05 }}
@@ -291,6 +311,14 @@ function TeamCard({ img, name, role }){
       <h5 className="font-semibold text-lg">{name}</h5>
       <p className="text-sm text-dsccOrange">{role}</p>
     </motion.div>
+  )
+
+  return link ? (
+    <a href={link} target="_blank" rel="noopener noreferrer">
+      {Card}
+    </a>
+  ) : (
+    Card
   )
 }
 

--- a/pages/team.js
+++ b/pages/team.js
@@ -35,18 +35,27 @@ export default function Page() {
         <div className="container mx-auto px-4 max-w-5xl">
           <h2 className="text-3xl font-bold mb-8 text-center">Équipe Pilotage</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-            {pilotageTeam.map(m => (
-              <div key={m.name} className="text-center">
-                <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
-                  <img src={`/team/${m.img}`} alt={m.name} className="object-cover w-full h-full" />
-                  <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white p-2 text-sm transition text-center">
-                    {quotesByRole[m.role]}
+            {pilotageTeam.map(m => {
+              const Card = (
+                <div className="text-center">
+                  <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
+                    <img src={`/team/${m.img}`} alt={m.name} className="object-cover w-full h-full" />
+                    <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white p-2 text-sm transition text-center">
+                      {quotesByRole[m.role]}
+                    </div>
                   </div>
+                  <p className="font-semibold">{m.name}</p>
+                  <p className="text-sm text-gray-500">{m.role}</p>
                 </div>
-                <p className="font-semibold">{m.name}</p>
-                <p className="text-sm text-gray-500">{m.role}</p>
-              </div>
-            ))}
+              )
+              return m.link ? (
+                <a key={m.name} href={m.link} target="_blank" rel="noopener noreferrer">
+                  {Card}
+                </a>
+              ) : (
+                Card
+              )
+            })}
           </div>
         </div>
       </AnimatedSection>
@@ -56,18 +65,27 @@ export default function Page() {
         <div className="container mx-auto px-4 max-w-5xl">
           <h2 className="text-3xl font-bold mb-8 text-center">Équipe Responsables</h2>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
-            {responsableTeam.map(m => (
-              <div key={m.name} className="text-center">
-                <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
-                  <img src={`/team/${m.img}`} alt={m.name} className="object-cover w-full h-full" />
-                  <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white p-2 text-sm transition text-center">
-                    {quotesByRole[m.role]}
+            {responsableTeam.map(m => {
+              const Card = (
+                <div className="text-center">
+                  <div className="h-32 w-32 mx-auto rounded-full bg-gray-200 mb-2 relative overflow-hidden">
+                    <img src={`/team/${m.img}`} alt={m.name} className="object-cover w-full h-full" />
+                    <div className="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-80 bg-dsccGreen text-white p-2 text-sm transition text-center">
+                      {quotesByRole[m.role]}
+                    </div>
                   </div>
+                  <p className="font-semibold">{m.name}</p>
+                  <p className="text-sm text-gray-500">{m.role}</p>
                 </div>
-                <p className="font-semibold">{m.name}</p>
-                <p className="text-sm text-gray-500">{m.role}</p>
-              </div>
-            ))}
+              )
+              return m.link ? (
+                <a key={m.name} href={m.link} target="_blank" rel="noopener noreferrer">
+                  {Card}
+                </a>
+              ) : (
+                Card
+              )
+            })}
           </div>
         </div>
       </AnimatedSection>
@@ -118,21 +136,60 @@ const quotesByRole = {
 }
 
 const pilotageTeam = [
-  { name: 'Jawad Elkharrati', role: 'Président', img: 'jawad.JPG' },
-  { name: 'Aya El Farssia', role: 'Vice-Présidente', img: 'aya.jpeg' },
-  { name: 'Hanae Cherif', role: 'Secrétaire', img: 'hanae.jpg' },
-  { name: 'Oumaima Sahli', role: 'Trésorière', img: 'oumaima.jpeg' },
+  {
+    name: 'Jawad Elkharrati',
+    role: 'Président',
+    img: 'jawad.JPG',
+    link: 'https://www.linkedin.com/in/jawad-elkharrati/'
+  },
+  {
+    name: 'Aya El Farssia',
+    role: 'Vice-Présidente',
+    img: 'aya.jpeg',
+    link: 'https://ma.linkedin.com/in/aya-el-fassi-3a451b1b9'
+  },
+  {
+    name: 'Hanae Cherif',
+    role: 'Secrétaire',
+    img: 'hanae.jpg',
+    link: 'https://ma.linkedin.com/in/hanae-cherif-31b218344'
+  },
+  {
+    name: 'Oumaima Sahli',
+    role: 'Trésorière',
+    img: 'oumaima.jpeg',
+    link: 'https://ma.linkedin.com/in/sahli-oumaima-b8ab8831b'
+  },
   { name: 'Iyad Beddidi', role: 'Responsable RH', img: 'iyad.jpeg' },
 ]
 
 const responsableTeam = [
-  { name: 'El Wazani Mohamed', role: 'Responsable Design', img: 'jawad.JPG' },
-  { name: 'Houciene Benhaddou', role: 'Responsable Maison de Science', img: 'houcein.jpg' },
-  { name: 'Safae Azizi', role: 'Responsable Média', img: 'safae.jpeg' },
+  {
+    name: 'El Wazani Mohamed',
+    role: 'Responsable Design',
+    img: 'jawad.JPG',
+    link: 'https://ma.linkedin.com/in/mohamed-wazane-827729313'
+  },
+  {
+    name: 'Houciene Benhaddou',
+    role: 'Responsable Maison de Science',
+    img: 'houcein.jpg'
+  },
+  {
+    name: 'Safae Azizi',
+    role: 'Responsable Média',
+    img: 'safae.jpeg',
+    link: 'https://ma.linkedin.com/in/azizi-safae-511326272'
+  },
   { name: 'Jinane Ait Elabd', role: 'Responsable Montage', img: 'jinane.png' },
   { name: 'Mostafa Alaoui', role: 'Responsable Logistique', img: 'mustafa.jpg' },
   { name: 'Amine Chakri', role: 'Responsable Compétition', img: 'amine.jpg' },
-  { name: 'EL MOUSSAOUI Oussama', role: 'Responsable Journée', img: 'oussama.jpg' },
+  {
+    name: 'EL MOUSSAOUI Oussama',
+    role: 'Responsable Journée',
+    img: 'oussama.jpg',
+    link: 'https://ma.linkedin.com/in/el-moussaoui-oussama-0a4a9524b'
+  },
   { name: 'Badreddine Chihab', role: 'Responsable Sponsoring', img: 'badr.jpeg' },
   { name: 'Wafae Zalouk', role: 'Responsable Rédaction', img: 'wafae.jpg' },
   { name: 'Zakaria Taibi', role: 'Responsable Formation', img: 'zakaria.jpg' },


### PR DESCRIPTION
## Summary
- make team profiles link to LinkedIn from the home page
- allow optional links for team cards
- add LinkedIn links and anchors for team page members

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ea5386c8833198a1c888a1dc32c6