### PR TITLE
Improve image alt text

### DIFF
--- a/lib/extractKeyword.js
+++ b/lib/extractKeyword.js
@@ -1,0 +1,6 @@
+export function extractKeyword(title = '') {
+  if (!title) return ''
+  const truncated = title.split(/[:\-?!]/)[0]
+  const words = truncated.trim().split(/\s+/)
+  return words.slice(0, 2).join(' ')
+}

--- a/pages/events.js
+++ b/pages/events.js
@@ -5,6 +5,7 @@ import ImageSlider from '../components/ImageSlider'
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { db } from '../lib/firebase'
+import { extractKeyword } from '../lib/extractKeyword'
 import {
   FaRegCalendarAlt,
   FaUsers,
@@ -120,7 +121,7 @@ export default function Page() {
               const img = (
                 <img
                   src={c.img}
-                  alt={c.title}
+                  alt={extractKeyword(c.title)}
                   className="w-full rounded-lg shadow hover:shadow-lg transition"
                 />
               )

--- a/pages/index.js
+++ b/pages/index.js
@@ -22,6 +22,7 @@ import {
 import AnimatedSection from '../components/AnimatedSection'
 import ProjectCard from '../components/ProjectCard'
 import { projects } from '../data/projects'
+import { extractKeyword } from '../lib/extractKeyword'
 
 export default function Home() {
   // Slides displayed in the hero section
@@ -156,7 +157,7 @@ export default function Home() {
               const img = (
                 <img
                   src={c.img}
-                  alt={c.title}
+                  alt={extractKeyword(c.title)}
                   className="w-full rounded-lg shadow hover:shadow-lg transition"
                 />
               )


### PR DESCRIPTION
## Summary
- add `extractKeyword` helper to shorten alt text
- apply shortened alt text on index and events pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f1b401588331b22f83f461fbaf31