### PR TITLE
Improve navigation and resources

### DIFF
--- a/components/Carousel.js
+++ b/components/Carousel.js
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa'
+
+export default function Carousel({ children, interval = 5000 }) {
+  const slides = React.Children.toArray(children)
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex(i => (i + 1) % slides.length)
+    }, interval)
+    return () => clearInterval(id)
+  }, [slides.length, interval])
+
+  const prev = () => setIndex(i => (i - 1 + slides.length) % slides.length)
+  const next = () => setIndex(i => (i + 1) % slides.length)
+
+  return (
+    <div className="relative w-full h-full">
+      <AnimatePresence mode="sync">
+        <motion.div
+          key={index}
+          className="w-full h-full"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.5 }}
+        >
+          {slides[index]}
+        </motion.div>
+      </AnimatePresence>
+      {slides.length > 1 && (
+        <>
+          <button
+            onClick={prev}
+            className="absolute left-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white text-dsccGreen rounded-full p-2"
+          >
+            <FaChevronLeft />
+          </button>
+          <button
+            onClick={next}
+            className="absolute right-2 top-1/2 -translate-y-1/2 bg-white/70 hover:bg-white text-dsccGreen rounded-full p-2"
+          >
+            <FaChevronRight />
+          </button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -77,6 +77,14 @@ export default function Page() {
                 referrerPolicy="no-referrer-when-downgrade"
               ></iframe>
             </div>
+            <a
+              href="https://www.google.com/maps/place/ENSA"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-dsccGreen underline inline-flex items-center gap-1 mb-4"
+            >
+              Ouvrir la carte
+            </a>
             <div className="flex gap-4">
               <a
                 href="https://www.instagram.com/clubdscc/"

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,6 +2,7 @@
 import { useState, useEffect } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import Link from 'next/link'
+import { FaChevronLeft, FaChevronRight } from 'react-icons/fa'
 import Counter from '../components/Counter'
 import Layout from '../components/Layout'
 import Image from 'next/image'
@@ -63,6 +64,23 @@ export default function Home() {
             transition={{ duration: 1 }}
           />
         </AnimatePresence>
+
+        {slides.length > 1 && (
+          <>
+            <button
+              onClick={() => setIndex(i => (i - 1 + slides.length) % slides.length)}
+              className="absolute left-4 top-1/2 -translate-y-1/2 z-10 bg-white/70 hover:bg-white text-dsccGreen rounded-full p-2"
+            >
+              <FaChevronLeft />
+            </button>
+            <button
+              onClick={() => setIndex(i => (i + 1) % slides.length)}
+              className="absolute right-4 top-1/2 -translate-y-1/2 z-10 bg-white/70 hover:bg-white text-dsccGreen rounded-full p-2"
+            >
+              <FaChevronRight />
+            </button>
+          </>
+        )}
         
         <div className="absolute inset-0 bg-dsccGreen/70" />
 

--- a/pages/python-lessons.js
+++ b/pages/python-lessons.js
@@ -162,10 +162,15 @@ def predict():
             <h2 className="text-2xl font-bold mb-2">📁 Structure conseillée</h2>
             <pre className="bg-lightGray p-4 rounded"><code>mon_projet/
 ├── data/
+│   ├── raw/
+│   └── processed/
 ├── notebooks/
-├── scripts/
-├── models/
-├── app/
+├── src/
+│   ├── scripts/
+│   ├── models/
+│   └── app/
+├── tests/
+├── docs/
 ├── requirements.txt
 └── README.md</code></pre>
           </section>

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import { FaArrowRight } from 'react-icons/fa'
 import { useState, useEffect } from 'react'
 import LaureatCard from '../components/LaureatCard'
-import CardSlider from '../components/CardSlider'
+import Carousel from '../components/Carousel'
 
 export default function Page() {
   const [drives, setDrives] = useState([])
@@ -86,16 +86,18 @@ export default function Page() {
       <AnimatedSection id="laureats" className="py-20 bg-white" direction="left">
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Nos lauréats</h2>
-          <CardSlider>
-            {firstHalf.map((l, i) => (
-              <LaureatCard key={i} {...l} />
-            ))}
-          </CardSlider>
-          <CardSlider>
-            {secondHalf.map((l, i) => (
-              <LaureatCard key={i} {...l} />
-            ))}
-          </CardSlider>
+          <div className="grid md:grid-cols-2 gap-8">
+            <Carousel>
+              {firstHalf.map((l, i) => (
+                <LaureatCard key={i} {...l} />
+              ))}
+            </Carousel>
+            <Carousel>
+              {secondHalf.map((l, i) => (
+                <LaureatCard key={i} {...l} />
+              ))}
+            </Carousel>
+          </div>
         </div>
       </AnimatedSection>
 


### PR DESCRIPTION
## Summary
- add Carousel component for manual slides
- allow manual navigation on hero slide
- update laureats section to use Carousel
- link to open map in Contact page
- improve recommended project structure in Python lessons

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ff3f943083319adc38438e906c67