### PR TITLE
Improve carousels and resize event cards

### DIFF
--- a/components/Carousel.js
+++ b/components/Carousel.js
@@ -1,16 +1,29 @@
 import React, { useRef, useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
+import { motion, useAnimation } from 'framer-motion'
 
-export default function Carousel({ children }) {
+export default function Carousel({ children, autoScroll = false, duration = 30 }) {
   const slides = React.Children.toArray(children)
+  const items = autoScroll ? [...slides, ...slides] : slides
   const [width, setWidth] = useState(0)
   const containerRef = useRef(null)
+  const innerRef = useRef(null)
+  const controls = useAnimation()
 
   useEffect(() => {
-    if (containerRef.current) {
-      setWidth(containerRef.current.scrollWidth - containerRef.current.offsetWidth)
+    if (innerRef.current && containerRef.current) {
+      const full = innerRef.current.scrollWidth
+      const visible = containerRef.current.offsetWidth
+      if (autoScroll) {
+        setWidth(full / 2 - visible)
+        controls.start({
+          x: -full / 2,
+          transition: { ease: 'linear', duration, repeat: Infinity }
+        })
+      } else {
+        setWidth(full - visible)
+      }
     }
-  }, [slides.length])
+  }, [items.length, autoScroll, duration, controls])
 
   return (
     <motion.div
@@ -18,11 +31,24 @@ export default function Carousel({ children }) {
       className="overflow-hidden cursor-grab active:cursor-grabbing"
     >
       <motion.div
+        ref={innerRef}
         drag="x"
         dragConstraints={{ right: 0, left: -width }}
+        dragElastic={0}
         className="flex gap-6 w-max"
+        animate={autoScroll ? controls : undefined}
+        onDragStart={() => controls.stop()}
+        onDragEnd={() => {
+          if (autoScroll && innerRef.current) {
+            const full = innerRef.current.scrollWidth
+            controls.start({
+              x: -full / 2,
+              transition: { ease: 'linear', duration, repeat: Infinity }
+            })
+          }
+        }}
       >
-        {slides.map((child, i) => (
+        {items.map((child, i) => (
           <div key={i} className="flex-shrink-0">
             {child}
           </div>

--- a/pages/about.js
+++ b/pages/about.js
@@ -3,6 +3,7 @@ import AnimatedSection from '../components/AnimatedSection'
 import Counter from '../components/Counter'
 import Image from 'next/image'
 import ImageSlider from '../components/ImageSlider'
+import Carousel from '../components/Carousel'
 import Link from 'next/link'
 import {
   FaProjectDiagram,
@@ -100,27 +101,23 @@ export default function Page() {
       <AnimatedSection className="py-20 bg-white" direction="right">
         <div className="container mx-auto px-4 max-w-5xl">
           <h2 className="text-3xl font-bold text-center mb-8">Ils nous font confiance</h2>
-          <div className="overflow-hidden h-40">
-            <div className="flex flex-nowrap items-center gap-10 w-max sponsor-scroll">
-              {Array.from({ length: 20 }, (_, i) => {
-                const logos = [
-                  '/sponsors/1631326041576.jfif',
-                  '/sponsors/49-1120_company_import.jpg',
-                  '/sponsors/Assabah-logo.jpg',
-                  '/sponsors/COMMUNE-OUJDA-LOGO-01.png',
-                  '/sponsors/Cerhso.jpg',
-                  '/sponsors/ENSA Oujda.png',
-                  '/sponsors/Screenshot 2025-07-06 204840.png',
-                  '/sponsors/Societe-Generale-Emploi-Recrutement.png',
-                  '/sponsors/images (1).jfif',
-                  '/sponsors/images.png',
-                  '/sponsors/unnamed.png'
-                ]
-                const src = logos[i % logos.length]
-                return <IconTrust key={i} src={src} />
-              })}
-            </div>
-          </div>
+          <Carousel autoScroll duration={30}>
+            {[
+              '/sponsors/1631326041576.jfif',
+              '/sponsors/49-1120_company_import.jpg',
+              '/sponsors/Assabah-logo.jpg',
+              '/sponsors/COMMUNE-OUJDA-LOGO-01.png',
+              '/sponsors/Cerhso.jpg',
+              '/sponsors/ENSA Oujda.png',
+              '/sponsors/Screenshot 2025-07-06 204840.png',
+              '/sponsors/Societe-Generale-Emploi-Recrutement.png',
+              '/sponsors/images (1).jfif',
+              '/sponsors/images.png',
+              '/sponsors/unnamed.png'
+            ].map((src, i) => (
+              <IconTrust key={i} src={src} />
+            ))}
+          </Carousel>
         </div>
       </AnimatedSection>
 

--- a/pages/events.js
+++ b/pages/events.js
@@ -122,7 +122,7 @@ export default function Page() {
                 <img
                   src={c.img}
                   alt={extractKeyword(c.title)}
-                  className="w-full rounded-lg shadow hover:shadow-lg transition"
+                  className="w-full max-w-xs mx-auto rounded-lg shadow hover:shadow-lg transition"
                 />
               )
               return c.link ? (

--- a/pages/index.js
+++ b/pages/index.js
@@ -19,6 +19,7 @@ import {
 } from 'react-icons/fa';
 import AnimatedSection from '../components/AnimatedSection'
 import ProjectCard from '../components/ProjectCard'
+import Carousel from '../components/Carousel'
 import { projects } from '../data/projects'
 import { extractKeyword } from '../lib/extractKeyword'
 
@@ -88,25 +89,23 @@ export default function Home() {
       <AnimatedSection id="trust" className="py-20 bg-gray-50" direction="right">
         <div className="container mx-auto px-4 max-w-5xl">
           <h2 className="text-3xl font-bold text-center mb-8">Ils nous font confiance</h2>
-          <div className="overflow-x-auto pb-2 no-scrollbar cursor-grab active:cursor-grabbing">
-            <div className="flex flex-nowrap items-center gap-10 w-max">
-              {[
-                '/sponsors/1631326041576.jfif',
-                '/sponsors/49-1120_company_import.jpg',
-                '/sponsors/Assabah-logo.jpg',
-                '/sponsors/COMMUNE-OUJDA-LOGO-01.png',
-                '/sponsors/Cerhso.jpg',
-                '/sponsors/ENSA Oujda.png',
-                '/sponsors/Screenshot 2025-07-06 204840.png',
-                '/sponsors/Societe-Generale-Emploi-Recrutement.png',
-                '/sponsors/images (1).jfif',
-                '/sponsors/images.png',
-                '/sponsors/unnamed.png'
-              ].map((src, i) => (
-                <IconTrust key={i} src={src} />
-              ))}
-            </div>
-          </div>
+          <Carousel autoScroll duration={30}>
+            {[
+              '/sponsors/1631326041576.jfif',
+              '/sponsors/49-1120_company_import.jpg',
+              '/sponsors/Assabah-logo.jpg',
+              '/sponsors/COMMUNE-OUJDA-LOGO-01.png',
+              '/sponsors/Cerhso.jpg',
+              '/sponsors/ENSA Oujda.png',
+              '/sponsors/Screenshot 2025-07-06 204840.png',
+              '/sponsors/Societe-Generale-Emploi-Recrutement.png',
+              '/sponsors/images (1).jfif',
+              '/sponsors/images.png',
+              '/sponsors/unnamed.png'
+            ].map((src, i) => (
+              <IconTrust key={i} src={src} />
+            ))}
+          </Carousel>
         </div>
       </AnimatedSection>
 
@@ -138,7 +137,7 @@ export default function Home() {
                 <img
                   src={c.img}
                   alt={extractKeyword(c.title)}
-                  className="w-full rounded-lg shadow hover:shadow-lg transition"
+                  className="w-full max-w-xs mx-auto rounded-lg shadow hover:shadow-lg transition"
                 />
               )
               return c.link ? (

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -86,13 +86,13 @@ export default function Page() {
       <AnimatedSection id="laureats" className="py-20 bg-white" direction="left">
         <div className="container mx-auto px-4">
           <h2 className="text-3xl font-bold mb-8 text-center">Nos lauréats</h2>
-          <div className="grid md:grid-cols-2 gap-8">
-            <Carousel>
+          <div className="space-y-8">
+            <Carousel autoScroll duration={30}>
               {firstHalf.map((l, i) => (
                 <LaureatCard key={i} {...l} />
               ))}
             </Carousel>
-            <Carousel>
+            <Carousel autoScroll duration={30}>
               {secondHalf.map((l, i) => (
                 <LaureatCard key={i} {...l} />
               ))}


### PR DESCRIPTION
## Summary
- support auto-scrolling carousels that can also be dragged
- animate the partners section with the new carousel
- update about page sponsors slider
- separate laureates carousels in resources page and auto-scroll them
- shrink event card images

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790573dc3083319e4c7c972192b5e2