### PR TITLE
Fix Safae Azizi LinkedIn link

### DIFF
--- a/pages/team.js
+++ b/pages/team.js
@@ -191,7 +191,7 @@ const responsableTeam = [
     name: 'Safae Azizi',
     role: 'Responsable Média',
     img: 'safae.jpeg',
-    link: 'https://ma.linkedin.com/in/azizi-safae-511326272'
+    link: 'http://www.linkedin.com/in/azizi-safae-1bb329319'
   },
   { name: 'Jinane Ait Elabd', role: 'Responsable Montage', img: 'jinane.png' },
   { name: 'Mostafa Alaoui', role: 'Responsable Logistique', img: 'mustafa.jpg' },


### PR DESCRIPTION
## Summary
- update Safae Azizi's LinkedIn URL

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_687a302de54483318f4d3c857e56e053