### PR TITLE
Add SEO metadata and favicon

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -2,17 +2,31 @@ import Head from 'next/head'
 import Header from './Header'
 import Footer from './Footer'
 
-export default function Layout({ children, title }) {
+const siteTitle = 'DSCC – Club Data Science & Cloud Computing ENSA Oujda'
+const siteDescription = 'Official site for DSCC – Club Data Science & Cloud Computing ENSA Oujda, promoting data science and cloud computing in Morocco.'
+const siteKeywords = 'Club Data Science ENSA Oujda, DSCC ENSA, Data Science Morocco club, cloud computing, ENSA Oujda'
+const siteUrl = 'https://clubdscc.vercel.app'
+const ogImage = '/favicon.png'
+
+export default function Layout({ children, title, description }) {
   return (
     <>
       <Head>
-        <title>{title ? `${title} | DSCC` : 'Data Science Club'}</title>
-        <meta name="description" content="Data Science Club ENSA" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title ? `${title} | DSCC` : siteTitle}</title>
+        <meta name='description' content={description || siteDescription} />
+        <meta name='keywords' content={siteKeywords} />
+        <meta name='viewport' content='width=device-width, initial-scale=1' />
+        <meta name='robots' content='index,follow' />
+        <meta property='og:title' content={siteTitle} />
+        <meta property='og:description' content={siteDescription} />
+        <meta property='og:type' content='website' />
+        <meta property='og:image' content={ogImage} />
+        <meta property='og:url' content={siteUrl} />
+        <link rel='icon' href='/favicon.png' />
       </Head>
-      <div className="min-h-screen flex flex-col">
+      <div className='min-h-screen flex flex-col'>
         <Header />
-        <main className="flex-grow  -mt-[81px]">{children}</main>
+        <main className='flex-grow  -mt-[81px]'>{children}</main>
         <Footer />
       </div>
     </>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://clubdscc.vercel.app/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://clubdscc.vercel.app/</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/about</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/events</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/projects</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/datathonx</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/team</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/resources</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/contact</loc>
+  </url>
+  <url>
+    <loc>https://clubdscc.vercel.app/join</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- enhance layout head with favicon, keywords, and Open Graph tags
- add robots.txt and sitemap.xml for search engines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive setup; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68929ddeb6a4833180d2cc1eb9f70d6c